### PR TITLE
Make build reproducible again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <project.build.outputTimestamp>2021-02-22T20:48:40Z</project.build.outputTimestamp>
 
-      <java.version>1.8</java.version>
+        <java.version>1.8</java.version>
         <liquibase.version>4.3.1</liquibase.version>
         <mysql.version>8.0.23</mysql.version>
         <percona.toolkit.version>3.3.0</percona.toolkit.version>
@@ -106,12 +106,14 @@
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -129,8 +131,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -165,14 +167,15 @@
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <skip>false</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <author>false</author>
                     <doctitle>Liquibase CDI ${project.version} API</doctitle>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
                     <stagingRepository>/tmp/maven-snapshot</stagingRepository>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <pushChanges>false</pushChanges>
+                    <releaseProfiles>release-sign-artifacts</releaseProfiles>
                 </configuration>
             </plugin>
             <plugin>
@@ -287,12 +288,6 @@
         <profile>
             <!-- Required for deployment to Sonatype -->
             <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>1.8</version>
+                                    <version>${java.version}</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,39 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <targetJdk>${java.version}</targetJdk>
+                    <printFailingErrors>true</printFailingErrors>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pmd</id>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>cpd-check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.2.0</version>
+                <executions>
+                    <execution>
+                        <id>spotbugs</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,27 @@
     </dependencies>
     <build>
         <plugins>
+            <!--
+              for reproducible builds, maven-jar-plugin, maven-source-plugin, maven-assembly-plugin
+              and maven-javadoc-plugin >= 3.2.0 is required.
+              See https://maven.apache.org/guides/mini/guide-reproducible-builds.html
+             -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.2.0</version>
@@ -156,9 +177,11 @@
                 <version>3.2.0</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <!-- reproducible builds: version >= 3.0.0-M1 will automatically update
+                     the property "project.build.outputTimestamp" during the release in the same
+                     commit that updates the version. -->
+                <version>3.0.0-M1</version>
                 <configuration>
                     <stagingRepository>/tmp/maven-snapshot</stagingRepository>
                     <mavenExecutorId>forked-path</mavenExecutorId>
@@ -183,6 +206,8 @@
                     <doclint>none</doclint>
                     <encoding>UTF-8</encoding>
                     <jarOutputDirectory>${project.basedir}/target</jarOutputDirectory>
+                    <!-- reproducible builds: avoid timestamps in generated files -->
+                    <notimestamp>true</notimestamp>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
* Fixes these warnings:
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.liquibase.ext:liquibase-percona:jar:4.3.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 113, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ line 173, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-resources-plugin is missing. @ line 107, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 166, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ line 131, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
See also https://travis-ci.org/github/liquibase/liquibase-percona/builds/763443785#L1539
* Add pmd and spotbugs
* Fix reproducible builds
    * Updated maven-jar-plugin
    * Added maven-source-plugin with explicit version
    * Updated maven-release-plugin
    * Fixed maven-javadoc-plugin configuration (notimestamp)
* Use ${java.version} in maven-enforcer-plugin

Fixes #85 

For more info about reproducible builds, see https://reproducible-builds.org/ and https://maven.apache.org/guides/mini/guide-reproducible-builds.html and https://github.com/jvm-repo-rebuild/reproducible-central
