### PR TITLE
Add a keepalive thread to keep liquibase's db connection alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,12 @@ The extension supports the following java system properties:
     This option enables the debug output of pt-osc by setting the environment variable `PTDEBUG` before
     starting pt-osc.
 
+*   `liquibase.percona.keepAlive`: true/false. **Default: true** Since liquibase-percona 4.3.6
+    This option allows to disable the keepalive thread if there are any problems with it. The keepalive thread
+    pings the database while pt-online-schema-change is executing. This avoids that the server closes
+    liquibase's connection as it is idle during pt-osc. The server variable "wait_timeout" controls
+    when the connection is considered stale and dropped by the server. This variable is used to
+    determine how often the server will be pinged.
 
 You can set these properties by using the standard java `-D` option:
 
@@ -451,6 +457,7 @@ integration test.
 ### Next Version
 
 *   [PR #112](https://github.com/liquibase/liquibase-percona/pull/112): Fixing typos - [Jasper Vandemalle](https://github.com/jasper-vandemalle)
+*   [#106](https://github.com/liquibase/liquibase-percona/issues/106): MySQL connection times out after pt-online-schema-change run
 
 ### Version 4.3.5 (2021-05-24)
 

--- a/src/it/connectionTimeout/invoker.properties
+++ b/src/it/connectionTimeout/invoker.properties
@@ -1,0 +1,19 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = pre-integration-test -Dliquibase.percona.path=${project.build.directory}/it/connectionTimeout
+
+# for negative testing
+# -Dliquibase.percona.keepAlive=false
+#

--- a/src/it/connectionTimeout/pom.xml
+++ b/src/it/connectionTimeout/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file 
+    distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under 
+    the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may 
+    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to 
+    in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
+    ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under 
+    the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>liquibase-percona-it-connectionTimeout</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>my-app</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.liquibase</groupId>
+                <artifactId>liquibase-maven-plugin</artifactId>
+                <version>@liquibase.version@</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>@project.groupId@</groupId>
+                        <artifactId>@project.artifactId@</artifactId>
+                        <version>@project.version@</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                        <version>@mysql.version@</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <changeLogFile>test-changelog.xml</changeLogFile>
+                    <driver>com.mysql.jdbc.Driver</driver>
+                    <url>jdbc:mysql://@config_host@:@config_port@/@config_dbname@?useSSL=false&amp;allowPublicKeyRetrieval=true</url>
+                    <username>@config_user@</username>
+                    <password>@config_password@</password>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>update</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>update</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/connectionTimeout/pt-online-schema-change
+++ b/src/it/connectionTimeout/pt-online-schema-change
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [ "$1" == "--version" ]; then
+    echo "pt-online-schema-change substitute 0.0.0"
+    exit 0
+fi
+
+WAIT_TIME=15
+
+echo "pt-osc dummy: waiting for ${WAIT_TIME} seconds..."
+sleep ${WAIT_TIME}s
+echo "done."

--- a/src/it/connectionTimeout/setup.groovy
+++ b/src/it/connectionTimeout/setup.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def con, s;
+try {
+    def props = new Properties();
+    props.setProperty("user", config_user)
+    props.setProperty("password", config_password)
+    con = new com.mysql.cj.jdbc.Driver().connect("jdbc:mysql://${config_host}:${config_port}?useSSL=false&allowPublicKeyRetrieval=true", props)
+    s = con.createStatement();
+    s.execute("DROP DATABASE IF EXISTS `${config_dbname}`")
+    s.execute("CREATE DATABASE `${config_dbname}`")
+    s.execute("SET GLOBAL wait_timeout = 10")
+} finally {
+    s?.close();
+    con?.close();
+}
+
+println "Prepared empty database `${config_dbname}`"
+
+// create directories under target to silence out liquibase plugin
+new File("${basedir}/target/classes").mkdirs()
+new File("${basedir}/target/test-classes").mkdirs()
+
+return true

--- a/src/it/connectionTimeout/test-changelog.xml
+++ b/src/it/connectionTimeout/test-changelog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd">
+
+    <changeSet id="1" author="Alice">
+        <createTable tableName="person">
+            <column name="name" type="varchar(255)">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2" author="Alice">
+        <addColumn tableName="person">
+            <column name="address" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/it/connectionTimeout/verify.groovy
+++ b/src/it/connectionTimeout/verify.groovy
@@ -1,0 +1,43 @@
+import java.sql.ResultSet;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+def buildLogText = buildLog.text;
+assert buildLogText.contains("pt-osc dummy: waiting for");
+assert buildLogText.contains("ChangeSet test-changelog.xml::2::Alice ran successfully")
+assert !buildLogText.contains("CommunicationsException: The last packet successfully received from the server was")
+
+def con, s;
+try {
+    def props = new Properties();
+    props.setProperty("user", config_user)
+    props.setProperty("password", config_password)
+    con = new com.mysql.cj.jdbc.Driver().connect("jdbc:mysql://${config_host}:${config_port}/${config_dbname}?useSSL=false&allowPublicKeyRetrieval=true", props)
+    s = con.createStatement();
+    s.execute("SET GLOBAL wait_timeout = 28800")
+} finally {
+    s?.close();
+    con?.close();
+}
+
+return true
+

--- a/src/main/java/liquibase/ext/percona/Configuration.java
+++ b/src/main/java/liquibase/ext/percona/Configuration.java
@@ -37,6 +37,8 @@ public final class Configuration {
     public static final String PERCONA_TOOLKIT_PATH = "liquibase.percona.path";
     /** Enable debug output for pt-osc. */
     public static final String PERCONA_TOOLKIT_DEBUG = "liquibase.percona.ptdebug";
+    /** Keep liquibase's database connection alive while pt-online-schema-change is running. */
+    public static final String KEEPALIVE = "liquibase.percona.keepAlive";
 
     private static final String DEFAULT_ADDITIONAL_OPTIONS = "--alter-foreign-keys-method=auto --nocheck-unique-key-change";
 
@@ -74,5 +76,9 @@ public final class Configuration {
 
     public static boolean isPerconaToolkitDebug() {
         return Boolean.parseBoolean(System.getProperty(PERCONA_TOOLKIT_DEBUG, "false"));
+    }
+
+    public static boolean isKeepAlive() {
+        return Boolean.parseBoolean(System.getProperty(KEEPALIVE, "true"));
     }
 }

--- a/src/main/scripts/download-toolkit.sh
+++ b/src/main/scripts/download-toolkit.sh
@@ -32,14 +32,18 @@ url=https://downloads.percona.com/downloads/percona-toolkit/${VERSION}/source/ta
 filename=percona-toolkit-${VERSION}.tar.gz
 target=percona-toolkit-${VERSION}
 
-echo "Downloading ${filename}..."
-curl \
-  --location \
-  --output ${filename} \
-  ${url}
-if [ $? -ne 0 ]; then
-  echo "Download from ${url} failed..."
-  exit 1
+if [ -e "${filename}" ]; then
+  echo "Skipping download ${filename}..."
+else
+  echo "Downloading ${filename}..."
+  curl \
+    --location \
+    --output ${filename} \
+    ${url}
+  if [ $? -ne 0 ]; then
+    echo "Download from ${url} failed..."
+    exit 1
+  fi
 fi
 
 echo "Extracting..."


### PR DESCRIPTION
This determines the "wait_timeout" variable of the current
connection and pings the connection in a separate thread
while pt-online-schema-change is executing.

The keepalive thread is enabled by default and can be disabled
with the system property "liquibase.percona.keepAlive=false".

Fixes #106 