### PR TITLE
Use catalogName instead of schemaName

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install Perl modules
+      uses: perl-actions/install-with-cpanm@v1
+      with:
+        install: |
+          DBD::mysql
     - name: Cache Local Maven Repository
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,8 +31,8 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
         distribution: 'adopt'
-    - name: Run Unit Tests With Maven
-      run: ./mvnw -B clean test --file pom.xml
+    - name: Run Unit and Integration Tests With Maven
+      run: ./mvnw -B clean verify --file pom.xml -Prun-its
 
   # This step is the automation to create a release based on a liquibase core bump
   # If a manual release is required, the steps below will need to be done manually prior

--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ integration test.
 ### Next Version
 
 *   [PR #112](https://github.com/liquibase/liquibase-percona/pull/112): Fixing typos - [Jasper Vandemalle](https://github.com/jasper-vandemalle)
+*   [#118](https://github.com/liquibase/liquibase-percona/pull/118): Use catalogName instead of schemaName
 
 ### Version 4.3.5 (2021-05-24)
 

--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,7 @@
                         <artifactId>maven-invoker-plugin</artifactId>
                         <configuration>
 <!--                             <debug>true</debug> -->
+                            <streamLogsOnFailures>true</streamLogsOnFailures>
                             <projectsDirectory>src/it</projectsDirectory>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <preBuildHookScript>setup</preBuildHookScript>

--- a/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
+++ b/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
@@ -149,7 +149,7 @@ public class PTOnlineSchemaChangeStatement extends RuntimeStatement {
         if (databaseName != null) {
             dsn.append("D=").append(databaseName);
         } else {
-            dsn.append("D=").append(database.getLiquibaseSchemaName());
+            dsn.append("D=").append(database.getLiquibaseCatalogName());
         }
         dsn.append(",t=").append(tableName);
 

--- a/src/test/java/liquibase/ext/percona/AbstractPerconaChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/AbstractPerconaChangeTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractPerconaChangeTest<T extends PerconaChange> {
         System.setProperty(Configuration.LIQUIBASE_PASSWORD, "root");
 
         database = new MySQLDatabase();
-        database.setLiquibaseSchemaName("testdb");
+        database.setLiquibaseCatalogName("testdb");
         DatabaseConnection conn = new MockDatabaseConnection("jdbc:mysql://user@localhost:3306/testdb",
                 "user@localhost");
         database.setConnection(conn);


### PR DESCRIPTION
This change is needed to make the plugin compatible with
liquibase 4.4.0. We use now the catalogName to determine
the database name used when executing pt-online-schema-change.

For MySQL catalogName and schemaName are synonymous.
