### PR TITLE
Added masking for slave password

### DIFF
--- a/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
+++ b/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
@@ -186,6 +186,8 @@ public class PTOnlineSchemaChangeStatement extends RuntimeStatement {
             sb.append(" ");
             if (s.startsWith("--password")) {
                 sb.append("--password=***");
+            } else if (s.startsWith("--slave-password")) {
+                sb.append("--slave-password=***");
             } else if (s.contains(" ")) {
                 sb.append(s.substring(0, s.indexOf('=') + 1)).append("\"").append(s.substring(s.indexOf('=') + 1))
                         .append("\"");

--- a/src/test/java/liquibase/ext/percona/PTOnlineSchemaChangeStatementTest.java
+++ b/src/test/java/liquibase/ext/percona/PTOnlineSchemaChangeStatementTest.java
@@ -88,6 +88,16 @@ public class PTOnlineSchemaChangeStatementTest {
     }
 
     @Test
+    public void testPrintCommandWithAdditionalOptions() {
+        System.setProperty(Configuration.ADDITIONAL_OPTIONS, "--slave-password=password");
+        PTOnlineSchemaChangeStatement statement = new PTOnlineSchemaChangeStatement("testdb", "person",
+                "ADD COLUMN new_column INT NULL", Optional.empty());
+        Assertions.assertEquals(
+                "pt-online-schema-change --slave-password=*** --alter=\"ADD COLUMN new_column INT NULL\" --password=*** --execute h=localhost,P=3306,u=user,D=testdb,t=person",
+                statement.printCommand(database));
+    }
+
+    @Test
     public void testAdditionalOptions() {
         System.setProperty(Configuration.ADDITIONAL_OPTIONS, "--config /tmp/percona.conf");
         PTOnlineSchemaChangeStatement statement = new PTOnlineSchemaChangeStatement("testdb", "person",


### PR DESCRIPTION
The slave password is not masked in the print command.

Fixed this issue by adding masking functionality for --slave-password, similar to how it is done for --password

* Fixes #183 
