### PR TITLE
Add version info to manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,17 @@
             </plugin>
 
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <configuration>
                     <targetJdk>${java.version}</targetJdk>


### PR DESCRIPTION
This allows a nicer output when using "liquibase --version".
Refs liquibase/liquibase#2845

The following entries will be added to `META-INF/MANIFEST.MF`:

```
Implementation-Title: Liquibase Percona Extension
Implementation-Version: 4.11.1-SNAPSHOT
Implementation-Vendor: Liquibase.org
```


With 4.11.0, this extension shows currently as

```
- lib/liquibase-percona.jar: liquibase-percona UNKNOWN
```


With this change, it should show as

```
- lib/liquibase-percona.jar: Liquibase Percona Extension 4.11.1-SNAPSHOT
```
