### PR TITLE
Install libdbd-mysql-perl with apt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Perl modules
-      uses: perl-actions/install-with-cpanm@v1
-      with:
-        install: |
-          DBD::mysql
+      run: |
+        sudo apt-get update
+        sudo apt-get install libdbd-mysql-perl
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -77,10 +77,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Perl modules
-        uses: perl-actions/install-with-cpanm@v1
-        with:
-          install: |
-            DBD::mysql
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbd-mysql-perl
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -119,10 +118,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Perl modules
-        uses: perl-actions/install-with-cpanm@v1
-        with:
-          install: |
-            DBD::mysql
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbd-mysql-perl
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,10 +21,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Perl modules
-      uses: perl-actions/install-with-cpanm@v1
-      with:
-        install: |
-          DBD::mysql
+      run: |
+        sudo apt-get update
+        sudo apt-get install libdbd-mysql-perl
 
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3


### PR DESCRIPTION
Replaces perl-actions/install-with-cpanm which uses deprecated node12