### PR TITLE
[ci] Fix deprecated set-output GitHub Action command

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,9 +41,9 @@ jobs:
           else
               RELEASE_NOTES="TODO"
           fi
-          echo "::set-output name=extensionVersion::${EXTENSION_VERSION}"
-          echo "::set-output name=liquibaseVersion::${LIQUIBASE_VERSION}"
-          echo "::set-output name=releaseNotes::${RELEASE_NOTES}"
+          echo "extensionVersion=${EXTENSION_VERSION}" >> $GITHUB_OUTPUT
+          echo "liquibaseVersion=${LIQUIBASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "releaseNotes=${RELEASE_NOTES}" >> $GITHUB_OUTPUT
           
           echo "extensionVersion=${EXTENSION_VERSION}"
           echo "liquibaseVersion=${LIQUIBASE_VERSION}"


### PR DESCRIPTION
> Prepare Versions and Create Tag
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
