### PR TITLE
Bump Percona Toolkit from 3.4.0 to 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ changes provided by liquibase-core.
 * Liquibase 4.0.0, 4.1.1, 4.2.2, 4.3.5, 4.4.3, 4.5.0, 4.6.2, 4.7.1, 4.8.0, 4.9.1, 4.10.0, 4.11.0, 4.12.0, 4.13.0, 4.14.0, 4.15.0 (liquibase-percona 4.15.0). Percona Toolkit 3.4.0.
 * Liquibase 4.16.0 (liquibase-percona 4.16.0). Percona Toolkit 3.4.0.
 * Liquibase 4.17.1 (liquibase-percona 4.17.1). Percona Toolkit 3.4.0.
+* Liquibase 4.18.0 (liquibase-percona 4.18.0). Percona Toolkit 3.5.0.
 
 ## Supported Changes and examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <liquibase.version>4.17.1</liquibase.version>
         <mysql.version>8.0.30</mysql.version>
         <mariadb.connector.version>3.1.0</mariadb.connector.version>
-        <percona.toolkit.version>3.4.0</percona.toolkit.version>
+        <percona.toolkit.version>3.5.0</percona.toolkit.version>
 
         <config_host>127.0.0.1</config_host>
         <!--


### PR DESCRIPTION
Percona Toolkit 3.5.0 has been released on 2022-11-28:
https://docs.percona.com/percona-toolkit/release_notes.html#v3-5-0-released-2022-11-28
