### PR TITLE
Fix percona toolkit download after Percona homepage change

### DIFF
--- a/src/main/scripts/download-toolkit.sh
+++ b/src/main/scripts/download-toolkit.sh
@@ -103,10 +103,10 @@ function determine_latest_toolkit()
 
     # percona way:
     local latest
-    latest=$(curl --silent https://www.percona.com/downloads/percona-toolkit/LATEST/)
+    latest=$(curl --silent https://docs.percona.com/percona-toolkit/release_notes.html)
 
     local version
-    version=$(echo "$latest"|grep -i 'selected="selected">Percona' | sed 's/.*\([0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*\).*/\1/')
+    version=$(echo "$latest"|grep -A 5 'id="percona-toolkit"'|tail -n +2|grep 'section id="'|head -1|sed 's/.*v\([0-9][0-9]*\)-\([0-9][0-9]*\)-\([0-9][0-9]*\).*/\1.\2.\3/')
 
     if [ "$version" = "" ]; then
       echo "Couldn't determine latest toolkit version!" >&2


### PR DESCRIPTION
The URL https://www.percona.com/downloads/percona-toolkit/LATEST/ no longer exists.
Now using https://docs.percona.com/percona-toolkit/release_notes.html to figure out the latest toolkit version.