### PR TITLE
Add support for SQL change type

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,36 @@ Corresponding command:
 
     pt-online-schema-change --alter="MODIFY email VARCHAR(400)" ...
 
+### Sql
 
+Since: liquibase-percona 4.20.0
+
+Automatic rollback supported? no
+
+Example:
+
+```xml
+<changeSet id="2" author="Alice">
+    <sql>ALTER TABLE person ADD COLUMN address VARCHAR(255) NULL</sql>
+</changeSet>
+```
+
+Corresponding command:
+
+    pt-online-schema-change --alter="ADD COLUMN address VARCHAR(255) NULL" ...
+
+Note that there are several limitations:
+
+* Percona toolkit won't be used, when the sql statements consists of multiple statements (e.g. separated by `;`).
+  In that case a warning will be logged and the sql change will be executed as usual
+  without the percona toolkit.
+* If the sql change is not an alter table statement, then a warning will be logged
+  and the sql change will be executed as usual without the percona toolkit.
+* Liquibase-percona tries to determine the table name. If that doesn't work, then a warning will be logged
+  and the sql change will be executed as usual without the percona toolkit.
+* This change type is active by default and percona toolkit will be used when possible.
+  It can be disabled as usual via system property `liquibase.percona.skipChanges`.
+* Be sure to test the changelog thoroughly.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This allows to perform a non-locking database upgrade.
     *   [DropIndex](#dropindex)
     *   [DropUniqueConstraint](#dropuniqueconstraint)
     *   [ModifyDataType](#modifydatatype)
+    *   [Sql](#sql)
 *   [Configuration](#configuration)
     *   [UsePercona flag](#usepercona-flag)
     *   [PerconaOptions flag](#perconaoptions-flag)

--- a/src/it/rawSql/pom.xml
+++ b/src/it/rawSql/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file 
+    distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under 
+    the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may 
+    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to 
+    in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
+    ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under 
+    the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>liquibase-percona-it-rawSql</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>my-app</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.liquibase</groupId>
+                <artifactId>liquibase-maven-plugin</artifactId>
+                <version>@liquibase.version@</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>@project.groupId@</groupId>
+                        <artifactId>@project.artifactId@</artifactId>
+                        <version>@project.version@</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                        <version>@mysql.version@</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <changeLogFile>test-changelog.xml</changeLogFile>
+                    <driver>com.mysql.jdbc.Driver</driver>
+                    <url>jdbc:mysql://@config_host@:@config_port@/@config_dbname@?useSSL=false&amp;allowPublicKeyRetrieval=true</url>
+                    <username>@config_user@</username>
+                    <password>@config_password@</password>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>updateSQL</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>updateSQL</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>update</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>update</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/rawSql/test-changelog.xml
+++ b/src/it/rawSql/test-changelog.xml
@@ -27,7 +27,7 @@
         -->
         <sql splitStatements="true">
                 ALTER TABLE person ADD COLUMN email2 VARCHAR(255) NULL;
-                CREATE TABLE other_person;
+                CREATE TABLE other_person (name VARCHAR(255) NOT NULL);
                 ALTER TABLE other_person ADD COLUMN age INT NULL;
         </sql>
     </changeSet>

--- a/src/it/rawSql/test-changelog.xml
+++ b/src/it/rawSql/test-changelog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd">
+
+    <changeSet id="1" author="Alice">
+        <createTable tableName="person">
+            <column name="name" type="varchar(255)">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2" author="Alice">
+        <sql>ALTER TABLE person ADD COLUMN address VARCHAR(255) NULL</sql>
+    </changeSet>
+
+    <changeSet id="3" author="Alice">
+        <sql>ALTER TABLE person ADD COLUMN email VARCHAR(255) NULL, ADD COLUMN age INT NULL</sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/it/rawSql/test-changelog.xml
+++ b/src/it/rawSql/test-changelog.xml
@@ -20,4 +20,22 @@
     <changeSet id="3" author="Alice">
         <sql>ALTER TABLE `person` ADD COLUMN email VARCHAR(255) NULL, ADD COLUMN `age` INT NULL</sql>
     </changeSet>
+
+    <changeSet id="4" author="Alice">
+        <!-- percona toolkit is not used for this, because these are multiple statements
+             and could potentially change different tables. Or do something completely different.
+        -->
+        <sql splitStatements="true">
+                ALTER TABLE person ADD COLUMN email2 VARCHAR(255) NULL;
+                CREATE TABLE other_person;
+                ALTER TABLE other_person ADD COLUMN age INT NULL;
+        </sql>
+    </changeSet>
+
+    <changeSet id="5" author="Alice">
+        <sql>
+            -- comments are also supported
+            ALTER TABLE person ADD COLUMN secondary_address VARCHAR(255) NULL</sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/it/rawSql/test-changelog.xml
+++ b/src/it/rawSql/test-changelog.xml
@@ -18,6 +18,6 @@
     </changeSet>
 
     <changeSet id="3" author="Alice">
-        <sql>ALTER TABLE person ADD COLUMN email VARCHAR(255) NULL, ADD COLUMN age INT NULL</sql>
+        <sql>ALTER TABLE `person` ADD COLUMN email VARCHAR(255) NULL, ADD COLUMN `age` INT NULL</sql>
     </changeSet>
 </databaseChangeLog>

--- a/src/it/rawSql/verify.groovy
+++ b/src/it/rawSql/verify.groovy
@@ -32,6 +32,10 @@ assert buildLogText.contains("Successfully altered `testdb`.`person`.")
 assert buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD COLUMN email VARCHAR(255) NULL, ADD COLUMN `age` INT NULL\" --password=*** --execute h=${config_host},P=${config_port},u=${config_user},D=testdb,t=person")
 assert buildLogText.contains("ChangeSet test-changelog.xml::3::Alice ran successfully")
 
+ // this message should be logged only twice: for updateSQL and update
+assert buildLogText.count("[WARNING] Not using percona toolkit, because multiple statements are not supported: ALTER TABLE person ADD COLUMN email2 VARCHAR(255) NULL;\n" +
+        "                CREATE TABLE other_person (name VARCHAR(255) NOT NULL);\n" +
+        "                ALTER TABLE other_person ADD COLUMN age INT NULL;\n") == 2
 assert !buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD COLUMN email2 VARCHAR(255) NULL\"")
 assert buildLogText.contains("Not using percona toolkit, because multiple statements are not supported:")
 

--- a/src/it/rawSql/verify.groovy
+++ b/src/it/rawSql/verify.groovy
@@ -32,6 +32,12 @@ assert buildLogText.contains("Successfully altered `testdb`.`person`.")
 assert buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD COLUMN email VARCHAR(255) NULL, ADD COLUMN `age` INT NULL\" --password=*** --execute h=${config_host},P=${config_port},u=${config_user},D=testdb,t=person")
 assert buildLogText.contains("ChangeSet test-changelog.xml::3::Alice ran successfully")
 
+assert !buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD COLUMN email2 VARCHAR(255) NULL\"")
+assert buildLogText.contains("Not using percona toolkit, because multiple statements are not supported:")
+
+assert buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD COLUMN secondary_address VARCHAR(255) NULL\" --password=*** --execute h=${config_host},P=${config_port},u=${config_user},D=testdb,t=person")
+assert buildLogText.contains("ChangeSet test-changelog.xml::5::Alice ran successfully")
+
 File sql = new File( basedir, 'target/liquibase/migrate.sql' )
 assert sql.exists()
 def sqlText = sql.text

--- a/src/it/rawSql/verify.groovy
+++ b/src/it/rawSql/verify.groovy
@@ -1,0 +1,67 @@
+import java.sql.ResultSet;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+def buildLogText = buildLog.text;
+assert buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD COLUMN address VARCHAR(255) NULL\"")
+assert buildLogText.contains("ChangeSet test-changelog.xml::2::Alice ran successfully")
+assert buildLogText.contains("Custom SQL executed")
+assert buildLogText.contains("Altering `testdb`.`person`...")
+assert buildLogText.contains("Successfully altered `testdb`.`person`.")
+assert buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD COLUMN email VARCHAR(255) NULL, ADD COLUMN age INT NULL\"")
+assert buildLogText.contains("ChangeSet test-changelog.xml::3::Alice ran successfully")
+
+File sql = new File( basedir, 'target/liquibase/migrate.sql' )
+assert sql.exists()
+def sqlText = sql.text;
+assert sqlText.contains("pt-online-schema-change")
+assert !sqlText.contains("password=${config_password}")
+
+def con, s;
+try {
+    def props = new Properties();
+    props.setProperty("user", config_user)
+    props.setProperty("password", config_password)
+    con = new com.mysql.cj.jdbc.Driver().connect("jdbc:mysql://${config_host}:${config_port}/${config_dbname}?useSSL=false&allowPublicKeyRetrieval=true", props)
+    s = con.createStatement();
+    r = s.executeQuery("DESCRIBE person")
+    assert r.next()
+    assertColumn(r, "name", "varchar(255)", "NO", null)
+    assert r.next()
+    assertColumn(r, "address", "varchar(255)", "YES", null)
+    assert r.next()
+    assertColumn(r, "email", "varchar(255)", "YES", null)
+    assert r.next()
+    // for MySQL 5.7, the type is int(11), for MySQL 8, it is int
+    assertColumn(r, "age", "int", "YES", null)
+    r.close()
+} finally {
+    s?.close();
+    con?.close();
+}
+
+def assertColumn(resultset, name, type, nullable, defaultValue) {
+    assert name == resultset.getString(1)
+    assert resultset.getString(2).contains(type)
+    assert nullable == resultset.getString(3)
+    assert defaultValue == resultset.getString(5)
+}

--- a/src/it/sharedScripts/allChanges/test-changelog.xml
+++ b/src/it/sharedScripts/allChanges/test-changelog.xml
@@ -71,4 +71,8 @@
     <changeSet id="11" author="Alice">
         <addPrimaryKey tableName="other_person" columnNames="id, name"/>
     </changeSet>
+
+    <changeSet id="12" author="Alice">
+        <sql>alter table other_person add column nickname varchar(255) null</sql>
+    </changeSet>
 </databaseChangeLog>

--- a/src/it/sharedScripts/allChanges/verify.groovy
+++ b/src/it/sharedScripts/allChanges/verify.groovy
@@ -1,4 +1,4 @@
-import java.sql.ResultSet;
+import java.sql.ResultSet
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -21,7 +21,7 @@ import java.sql.ResultSet;
 
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
-def buildLogText = buildLog.text;
+def buildLogText = buildLog.text
 def defaultOptions = '--alter-foreign-keys-method=auto --no-check-unique-key-change --no-check-alter'
 if ( binding.hasVariable( 'isMariaDB' ) ) {
     assert buildLogText.contains("--password=*** --execute h=${config_host},P=${config_port_mariadb},u=${config_user},D=testdb,t=person")
@@ -51,10 +51,12 @@ assert buildLogText.contains("ChangeSet test-changelog.xml::9::Alice ran success
 assert buildLogText.contains("ChangeSet test-changelog.xml::10::Alice ran successfully")
 assert buildLogText.contains("Executing: ${perconaFullPath} ${defaultOptions} --alter=\"DROP PRIMARY KEY, ADD PRIMARY KEY (id, name)\"")
 assert buildLogText.contains("ChangeSet test-changelog.xml::11::Alice ran successfully")
+assert buildLogText.contains("Executing: ${perconaFullPath} ${defaultOptions} --alter=\"add column nickname varchar(255) null\"")
+assert buildLogText.contains("ChangeSet test-changelog.xml::12::Alice ran successfully")
 
 File sql = new File( basedir, 'target/liquibase/migrate.sql' )
 assert sql.exists()
-def sqlText = sql.text;
+def sqlText = sql.text
 assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"ADD COLUMN age INT NULL\"")
 assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"DROP COLUMN age\"")
 assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"ADD UNIQUE INDEX emailIdx (email)\"")
@@ -62,6 +64,8 @@ assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"DRO
 assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"MODIFY email VARCHAR(400)\"")
 assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"ADD CONSTRAINT fk_person_address FOREIGN KEY (person_id) REFERENCES person (name)\"")
 assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"DROP FOREIGN KEY _fk_person_address\"")
-// Note: only adding the primary key, not dropping it in the migration sql.
+// Note: only adding the primary key, not dropping it in the migration sql. When generating the migration sql
+// no database connection is used, so we don't check whether the table already contains a primary key.
 assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"ADD PRIMARY KEY (id, name)\"")
+assert sqlText.contains("pt-online-schema-change ${defaultOptions} --alter=\"add column nickname varchar(255) null\"")
 assert !sqlText.contains("password=${config_password}")

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -1,0 +1,120 @@
+package liquibase.ext.percona;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.change.DatabaseChangeProperty;
+import liquibase.change.core.RawSQLChange;
+import liquibase.database.Database;
+import liquibase.statement.SqlStatement;
+
+@DatabaseChange(
+        name = PerconaRawSQLChange.NAME,
+        description = "The 'sql' tag allows you to specify whatever sql you want. It is useful for complex changes that aren't supported through Liquibase's automated refactoring tags and to work around bugs and limitations of Liquibase. The SQL contained in the sql tag can be multi-line.\n\nThe createProcedure refactoring is the best way to create stored procedures.\n\nThe 'sql' tag can also support multiline statements in the same file. Statements can either be split using a ; at the end of the last line of the SQL or a 'GO' on its own on the line between the statements can be used. Multiline SQL statements are also supported and only a ; or GO statement will finish a statement, a new line is not enough. Files containing a single statement do not need to use a ; or GO.\n\nThe sql change can also contain comments of either of the following formats:\n\nA multiline comment that starts with /* and ends with */.\nA single line comment starting with <space>--<space> and finishing at the end of the line.\nNote: By default it will attempt to split statements on a ';' or 'go' at the end of lines. Because of this, if you have a comment or some other non-statement ending ';' or 'go', don't have it at the end of a line or you will get invalid SQL.",
+        priority = PerconaRawSQLChange.PRIORITY
+)
+public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
+    public static final String NAME = "sql";
+    public static final int PRIORITY = ChangeMetaData.PRIORITY_DEFAULT + 50;
+
+    private static final String ALTER_TABLE_PREFIX = "alter table ";
+
+    @Override
+    public SqlStatement[] generateStatements(Database database) {
+        return PerconaChangeUtil.generateStatements(this,
+                database,
+                super.generateStatements(database));
+    }
+
+    @Override
+    public String generateAlterStatement(Database database) {
+        String sql = getSql();
+        if (sql == null) {
+            return null;
+        }
+
+        String tableName = getTargetTableName();
+        return sql.substring(sql.indexOf(tableName) + tableName.length() + 1);
+    }
+
+    @Override
+    public String getTargetDatabaseName() {
+        // will fall back to Database#getLiquibaseCatalogName(), see PTOnlineSchemaChangeStatement
+        return null;
+    }
+
+    @Override
+    public String getTargetTableName() {
+        String sql = getSql();
+        if (sql == null) {
+            return null;
+        }
+
+        String lowerCaseSql = sql.toLowerCase(Locale.ROOT);
+        if (lowerCaseSql.trim().startsWith(ALTER_TABLE_PREFIX)) {
+            String table = sql.substring(sql.indexOf(ALTER_TABLE_PREFIX) + ALTER_TABLE_PREFIX.length());
+            table = table.substring(0, table.indexOf(' '));
+            return table;
+        }
+        return null;
+    }
+
+    //CPD-OFF - common PerconaChange implementation
+    private Boolean usePercona;
+
+    private String perconaOptions;
+
+    @Override
+    public String getChangeName() {
+        return NAME;
+    }
+
+    @Override
+    @DatabaseChangeProperty(requiredForDatabase = {})
+    public Boolean getUsePercona() {
+        return usePercona;
+    }
+
+    @Override
+    public void setUsePercona(Boolean usePercona) {
+        this.usePercona = usePercona;
+    }
+
+    @Override
+    @DatabaseChangeProperty(requiredForDatabase = {})
+    public String getPerconaOptions() {
+        return perconaOptions;
+    }
+
+    @Override
+    public void setPerconaOptions(String perconaOptions) {
+        this.perconaOptions = perconaOptions;
+    }
+
+    @Override
+    public Set<String> getSerializableFields() {
+        Set<String> fields = new HashSet<>(super.getSerializableFields());
+        fields.remove("usePercona");
+        fields.remove("perconaOptions");
+        return Collections.unmodifiableSet(fields);
+    }
+    //CPD-ON
+}

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -105,12 +105,13 @@ public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
                 table = table.substring(1, table.length() - 1);
             } else if (firstChar == '`') {
                 // only beginning escape, no closing. See warning above.
-                log.warning("Can't parse sql statement: too complicated: " + sql);
+                log.warning("Not using percona toolkit, because can't parse sql statement: " + sql);
                 return null;
             }
 
             return table;
         }
+        log.warning("Not using percona toolkit, because this sql statement is not an alter table: " + sql);
         return null;
     }
 

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -121,13 +121,12 @@ public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
             }
 
             // rename table?
-            if (tokens.length >= 4 && tokens[3].equalsIgnoreCase("rename")) {
-                if (tokens.length >= 5 && !tokens[4].equalsIgnoreCase("column")
-                        && !tokens[4].equalsIgnoreCase("index")
-                        && !tokens[4].equalsIgnoreCase("key")) {
-                    log.warning("Not using percona toolkit, because can't rename table: " + sql);
-                    return null;
-                }
+            if (tokens.length >= 5 && tokens[3].equalsIgnoreCase("rename")
+                    && !tokens[4].equalsIgnoreCase("column")
+                    && !tokens[4].equalsIgnoreCase("index")
+                    && !tokens[4].equalsIgnoreCase("key")) {
+                log.warning("Not using percona toolkit, because can't rename table: " + sql);
+                return null;
             }
 
             return table;

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -70,7 +70,7 @@ public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
 
         String lowerCaseSql = sql.toLowerCase(Locale.ROOT);
         if (lowerCaseSql.trim().startsWith(ALTER_TABLE_PREFIX)) {
-            String table = sql.substring(sql.indexOf(ALTER_TABLE_PREFIX) + ALTER_TABLE_PREFIX.length());
+            String table = sql.substring(sql.toLowerCase(Locale.ROOT).indexOf(ALTER_TABLE_PREFIX) + ALTER_TABLE_PREFIX.length());
             table = table.substring(0, table.indexOf(' '));
             return table;
         }

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -41,6 +41,12 @@ public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
 
     @Override
     public SqlStatement[] generateStatements(Database database) {
+        String table = getTargetTableName();
+        if (table == null) {
+            // can't use percona toolkit for whatever reason
+            return super.generateStatements(database);
+        }
+
         return PerconaChangeUtil.generateStatements(this,
                 database,
                 super.generateStatements(database));

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -120,6 +120,16 @@ public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
                 return null;
             }
 
+            // rename table?
+            if (tokens.length >= 4 && tokens[3].equalsIgnoreCase("rename")) {
+                if (tokens.length >= 5 && !tokens[4].equalsIgnoreCase("column")
+                        && !tokens[4].equalsIgnoreCase("index")
+                        && !tokens[4].equalsIgnoreCase("key")) {
+                    log.warning("Not using percona toolkit, because can't rename table: " + sql);
+                    return null;
+                }
+            }
+
             return table;
         }
         log.warning("Not using percona toolkit, because this sql statement is not an alter table: " + sql);

--- a/src/main/resources/META-INF/services/liquibase.change.Change
+++ b/src/main/resources/META-INF/services/liquibase.change.Change
@@ -22,3 +22,4 @@ liquibase.ext.percona.PerconaDropForeignKeyConstraintChange
 liquibase.ext.percona.PerconaDropIndexChange
 liquibase.ext.percona.PerconaDropUniqueConstraintChange
 liquibase.ext.percona.PerconaModifyDataTypeChange
+liquibase.ext.percona.PerconaRawSQLChange

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -41,6 +41,12 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
     }
 
     @Test
+    public void testGenerateAlterStatement() {
+        PerconaRawSQLChange change = getChange();
+        Assertions.assertEquals(alterText, change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
     public void testTargetTableNameAndAlterStatementKeepCase() {
         PerconaRawSQLChange change = getChange();
         change.setSql("altEr tAble pErSoN " + alterText);
@@ -49,9 +55,24 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
     }
 
     @Test
-    public void testGenerateAlterStatement() {
+    public void testTargetTableNameAndAlterStatementWithSpaces() {
         PerconaRawSQLChange change = getChange();
+        change.setSql("  altEr   tAble   pErSoN   " + alterText + "  ");
+        Assertions.assertEquals("pErSoN", change.getTargetTableName());
         Assertions.assertEquals(alterText, change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
+    public void testTargetTableNameAndAlterStatementWithEscapes() {
+        PerconaRawSQLChange change = getChange();
+        String alterTextEscaped = "ADD COLUMN `address` VARCHAR(255) NULL";
+        change.setSql("altEr tAble `pErSoN` " + alterTextEscaped);
+        Assertions.assertEquals("pErSoN", change.getTargetTableName());
+        Assertions.assertEquals(alterTextEscaped, change.generateAlterStatement(getDatabase()));
+
+        change.setSql("altEr tAble `my pErSoN table` " + alterTextEscaped);
+        Assertions.assertNull(change.getTargetTableName());
+        Assertions.assertNull(change.generateAlterStatement(getDatabase()));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -41,10 +41,17 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
     }
 
     @Test
-    public void testGetTargetTableNameKeepCase() {
+    public void testTargetTableNameAndAlterStatementKeepCase() {
         PerconaRawSQLChange change = getChange();
-        change.setSql("alter table pErSoN " + alterText);
+        change.setSql("altEr tAble pErSoN " + alterText);
         Assertions.assertEquals("pErSoN", change.getTargetTableName());
+        Assertions.assertEquals(alterText, change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
+    public void testGenerateAlterStatement() {
+        PerconaRawSQLChange change = getChange();
+        Assertions.assertEquals(alterText, change.generateAlterStatement(getDatabase()));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -76,6 +76,14 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
     }
 
     @Test
+    public void testTargetTableNameAndAlterStatementForInsert() {
+        PerconaRawSQLChange change = getChange();
+        change.setSql("insert into person (name) values ('Bob')");
+        Assertions.assertNull(change.getTargetTableName());
+        Assertions.assertNull(change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
     public void testGetTargetDatabaseName() {
         PerconaRawSQLChange change = getChange();
         Assertions.assertNull(change.getTargetDatabaseName());

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -110,6 +110,30 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
     }
 
     @Test
+    public void testTargetTableNameAndAlterStatementForRename() {
+        PerconaRawSQLChange change = getChange();
+        change.setSql("alter table person rename new_person");
+        Assertions.assertNull(change.getTargetTableName());
+        Assertions.assertNull(change.generateAlterStatement(getDatabase()));
+        change.setSql("alter table person rename to new_person");
+        Assertions.assertNull(change.getTargetTableName());
+        Assertions.assertNull(change.generateAlterStatement(getDatabase()));
+        change.setSql("alter table person rename as new_person");
+        Assertions.assertNull(change.getTargetTableName());
+        Assertions.assertNull(change.generateAlterStatement(getDatabase()));
+
+        change.setSql("alter table person rename column name to new_name");
+        Assertions.assertEquals("person", change.getTargetTableName());
+        Assertions.assertEquals("rename column name to new_name", change.generateAlterStatement(getDatabase()));
+        change.setSql("alter table person rename index name to new_name");
+        Assertions.assertEquals("person", change.getTargetTableName());
+        Assertions.assertEquals("rename index name to new_name", change.generateAlterStatement(getDatabase()));
+        change.setSql("alter table person rename key name to new_name");
+        Assertions.assertEquals("person", change.getTargetTableName());
+        Assertions.assertEquals("rename key name to new_name", change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
     public void testGetTargetDatabaseName() {
         PerconaRawSQLChange change = getChange();
         Assertions.assertNull(change.getTargetDatabaseName());

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -101,6 +101,15 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
     }
 
     @Test
+    public void testTargetTableNameAndAlterStatementForMultipleAlterOptionsSameTable() {
+        PerconaRawSQLChange change = getChange();
+        String alterMultipleOptions = "add address varchar(255) null, add age int null";
+        change.setSql("alter table person " + alterMultipleOptions);
+        Assertions.assertEquals("person", change.getTargetTableName());
+        Assertions.assertEquals(alterMultipleOptions, change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
     public void testGetTargetDatabaseName() {
         PerconaRawSQLChange change = getChange();
         Assertions.assertNull(change.getTargetDatabaseName());

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -84,6 +84,23 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
     }
 
     @Test
+    public void testTargetTableNameAndAlterStatementForMultipleStatements() {
+        PerconaRawSQLChange change = getChange();
+        change.setSplitStatements(true);
+        change.setSql("alter table person " + alterText + "; alter table person " + alterText + ";");
+        Assertions.assertNull(change.getTargetTableName());
+        Assertions.assertNull(change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
+    public void testTargetTableNameAndAlterStatementWithComment() {
+        PerconaRawSQLChange change = getChange();
+        change.setSql("-- multiline\nalter table person " + alterText + ";\n/* other\ncomment */");
+        Assertions.assertEquals("person", change.getTargetTableName());
+        Assertions.assertEquals(alterText, change.generateAlterStatement(getDatabase()));
+    }
+
+    @Test
     public void testGetTargetDatabaseName() {
         PerconaRawSQLChange change = getChange();
         Assertions.assertNull(change.getTargetDatabaseName());

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -1,0 +1,124 @@
+package liquibase.ext.percona;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.CommentStatement;
+import liquibase.statement.core.RawSqlStatement;
+
+public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRawSQLChange> {
+
+    public PerconaRawSQLChangeTest() {
+        super(PerconaRawSQLChange.class);
+    }
+
+    @Override
+    protected void setupChange(PerconaRawSQLChange change) {
+        alterText = "ADD COLUMN address VARCHAR(255) NULL";
+        change.setSql("alter table person " + alterText);
+    }
+
+    @Test
+    public void testGetTargetTableName() {
+        PerconaRawSQLChange change = getChange();
+        Assertions.assertEquals("person", change.getTargetTableName());
+    }
+
+    @Test
+    public void testGetTargetTableNameKeepCase() {
+        PerconaRawSQLChange change = getChange();
+        change.setSql("alter table pErSoN " + alterText);
+        Assertions.assertEquals("pErSoN", change.getTargetTableName());
+    }
+
+    @Test
+    public void testGetTargetDatabaseName() {
+        PerconaRawSQLChange change = getChange();
+        Assertions.assertNull(change.getTargetDatabaseName());
+    }
+
+    @Test
+    public void testWithoutPercona() {
+        PTOnlineSchemaChangeStatement.available = false;
+        SqlStatement[] statements = generateStatements();
+        Assertions.assertEquals(1, statements.length);
+        Assertions.assertEquals(RawSqlStatement.class, statements[0].getClass());
+    }
+
+    @Test
+    public void testWithoutPerconaAndFail() {
+        System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
+        PTOnlineSchemaChangeStatement.available = false;
+
+        Assertions.assertThrows(RuntimeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                generateStatements();
+            }
+        });
+    }
+
+    @Test
+    public void testReal() {
+        assertPerconaChange(alterText);
+    }
+
+    @Test
+    public void testUpdateSQL() {
+        enableLogging();
+
+        SqlStatement[] statements = generateStatements();
+        Assertions.assertEquals(3, statements.length);
+        Assertions.assertEquals(CommentStatement.class, statements[0].getClass());
+        Assertions.assertEquals("pt-online-schema-change "
+                        + "--alter-foreign-keys-method=auto "
+                        + "--nocheck-unique-key-change "
+                        + "--alter=\"" + alterText + "\" "
+                        + "--password=*** --execute "
+                        + "h=localhost,P=3306,u=user,D=testdb,t=person",
+                ((CommentStatement)statements[0]).getText());
+        Assertions.assertEquals(CommentStatement.class, statements[1].getClass());
+        Assertions.assertEquals(RawSqlStatement.class, statements[2].getClass());
+    }
+
+    @Test
+    public void testUpdateSQLNoAlterSqlDryMode() {
+        enableLogging();
+        System.setProperty(Configuration.NO_ALTER_SQL_DRY_MODE, "true");
+
+        SqlStatement[] statements = generateStatements();
+        Assertions.assertEquals(1, statements.length);
+        Assertions.assertEquals(CommentStatement.class, statements[0].getClass());
+        Assertions.assertEquals("pt-online-schema-change "
+                        + "--alter-foreign-keys-method=auto "
+                        + "--nocheck-unique-key-change "
+                        + "--alter=\"" + alterText + "\" "
+                        + "--password=*** --execute "
+                        + "h=localhost,P=3306,u=user,D=testdb,t=person",
+                ((CommentStatement)statements[0]).getText());
+    }
+
+    @Test
+    public void testSkipRawSQLChange() {
+        System.setProperty(Configuration.SKIP_CHANGES, "sql");
+        SqlStatement[] statements = generateStatements();
+        Assertions.assertEquals(1, statements.length);
+        Assertions.assertEquals(RawSqlStatement.class, statements[0].getClass());
+    }
+}


### PR DESCRIPTION
### Support for Custom SQL changes

You can now use [Custom SQL changes](https://docs.liquibase.com/change-types/sql.html). The Liquibase Percona extension will automatically detect if it is a `ALTER TABLE` statement and will execute it using Percona Toolkit's `pt-online-schema-change` command.

There are some limitations: Only a single statement is supported. When multiple statements (e.g. separated by `;`) are used, then the change is executed as usual. Also, if it is
not an `ALTER TABLE` statement, the change is executed as usual without Percona Toolkit. If the statement can't be executed, a warning is logged

| :warning:   Support for Custom SQL changes is enabled by default. <br> The Liquibase Percona extension will automatically try to execute Custom SQL changes via the Percona Toolkit. If this is not what you want, either disable the extension for this change globally (e.g. via the system property `liquibase.percona.skipChanges=sql`) or individually per change via the [UsePercona flag](https://github.com/liquibase/liquibase-percona#usepercona-flag). You can also globally disable Percona Toolkit usage with the system property `liquibase.percona.defaultOn` and enable it for specific changes only. See [System Properties](https://github.com/liquibase/liquibase-percona#system-properties). |
|-----|

Example usage in XML:

```xml
<databaseChangeLog>
  <changeSet id="2" author="Alice">
    <sql>ALTER TABLE person ADD COLUMN address VARCHAR(255) NULL</sql>
  </changeSet>
  <changeSet id="3" author="Alice">
    <sql xmlns:liquibasePercona="http://www.liquibase.org/xml/ns/dbchangelog-ext/liquibase-percona"
         liquibasePercona:usePercona="false">
        ALTER TABLE person ADD COLUMN address VARCHAR(255) NULL
    </sql>
  </changeSet>
</databaseChangeLog>
```

Example usage in YAML:

```yaml
databaseChangeLog:
- changeSet:
    id: 2
    author: Alice
    changes:
    - sql:
        splitStatements: true
        sql: |
            ALTER TABLE person ADD COLUMN address VARCHAR(255) NULL;
- changeSet:
    id: 3
    author: Alice
    changes:
    - sql:
        usePercona: false
        splitStatements: true
        sql: |
            ALTER TABLE person ADD COLUMN address VARCHAR(255) NULL;
```

- Fixes #80 

<details>

TODOs:
- [x] update allChanges integration tests
- [x] test with escaped table name, e.g. <code>ALTER TABLE &#96;person&#96;</code>
- [x] don't execute pt-osc if it is not a alter table statement. Log a warning.
- [x] check for multiple (alter table) statements -> don't execute
- [x] allow comma separate multiple alter options (e.g. multiple columns, same table)
- [x] check for not supported alter changes, e.g. table renames?
- [x] Update documentation

TODO after merge:
- [x] Create a release notes issue to highlight this change - as possible compatibility problem. The extension would now also execute sql changes via pt-osc, which is not necessarily what one wants by default. See [Using the summary section feature](https://github.com/github-changelog-generator/github-changelog-generator#using-the-summary-section-feature): #293

</details>
