### PR TITLE
Add support for Formatted SQL changelogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This allows to perform a non-locking database upgrade.
 ## Table Of Contents
 
 *   [Supported Databases](#supported-databases)
+*   [Supported Changeset Formats](#supported-changeset-formats)
 *   [Liquibase version(s) tested against](#liquibase-versions-tested-against)
 *   [Supported Changes and examples](#supported-changes-and-examples)
     *   [AddColumn](#addcolumn)
@@ -52,6 +53,13 @@ MySQL and MariaDB (since 4.3.2) are the only supported databases.
 The extension checks whether it is being run against a MySQL/MariaDB database. If not, it falls back to the default
 changes provided by liquibase-core.
 
+## Supported Changeset Formats
+
+This liquibase extension supports the following changeset formats:
+
+* [XML](https://docs.liquibase.com/concepts/changelogs/xml-format.html)
+* [YAML](https://docs.liquibase.com/concepts/changelogs/yaml-format.html)
+* [Formatted SQL](https://docs.liquibase.com/concepts/changelogs/sql-format.html) (since liquibase-percona 4.20.0)
 
 ## Liquibase version(s) tested against
 
@@ -362,6 +370,14 @@ It is supported by using the YAML format and since liquibase 3.6.0, you can use 
 </addColumn>
 ```
 
+Since liquibase-percona 4.20.0, you can use it in SQL changeset as follows:
+
+```sql
+--changeset Alice:2
+--liquibasePercona:usePercona="false"
+ALTER TABLE person ADD address VARCHAR(255) NULL;
+```
+
 ### PerconaOptions flag
 
 Each change allows to specify options that are used when executing pt-osc. If specified, this option
@@ -394,6 +410,14 @@ It is supported by using the YAML format and in XML changesets:
         liquibasePercona:perconaOptions="--alter-foreign-keys-method=auto">
     <column name="address" type="varchar(255)"/>
 </addColumn>
+```
+
+Since liquibase-percona 4.20.0 this is also supported in SQL changesets:
+
+```sql
+--changeset Alice:2
+--liquibasePercona:perconaOptions="--alter-foreign-keys-method=auto"
+ALTER TABLE person ADD email VARCHAR(255) NULL;
 ```
 
 ### System Properties

--- a/src/it/addColumnSqlChangelog/pom.xml
+++ b/src/it/addColumnSqlChangelog/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file 
+    distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under 
+    the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may 
+    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to 
+    in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
+    ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under 
+    the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>liquibase-percona-it-addColumnSqlChangelog</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>my-app</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.liquibase</groupId>
+                <artifactId>liquibase-maven-plugin</artifactId>
+                <version>@liquibase.version@</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>@project.groupId@</groupId>
+                        <artifactId>@project.artifactId@</artifactId>
+                        <version>@project.version@</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                        <version>@mysql.version@</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <changeLogFile>test-changelog.sql</changeLogFile>
+                    <driver>com.mysql.jdbc.Driver</driver>
+                    <url>jdbc:mysql://@config_host@:@config_port@/@config_dbname@?useSSL=false&amp;allowPublicKeyRetrieval=true</url>
+                    <username>@config_user@</username>
+                    <password>@config_password@</password>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>updateSQL</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>updateSQL</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>update</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>update</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/addColumnSqlChangelog/test-changelog.sql
+++ b/src/it/addColumnSqlChangelog/test-changelog.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset Alice:1
+--liquibasePercona:usePercona="false"
+CREATE TABLE person (name VARCHAR(255) NOT NULL, CONSTRAINT PK_PERSON PRIMARY KEY (name));
+
+--changeset Alice:2
+ALTER TABLE person ADD address VARCHAR(255) NULL;
+
+--changeset Alice:3
+--liquibasePercona:usePercona="false"
+ALTER TABLE person ADD email VARCHAR(255) NULL;

--- a/src/it/addColumnSqlChangelog/verify.groovy
+++ b/src/it/addColumnSqlChangelog/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+def buildLogText = buildLog.text
+assert buildLogText.contains("Executing: pt-online-schema-change --alter-foreign-keys-method=auto --nocheck-unique-key-change --alter=\"ADD address VARCHAR(255) NULL\"")
+assert buildLogText.contains("ChangeSet test-changelog.sql::2::Alice ran successfully")
+assert buildLogText.contains("Successfully altered `testdb`.`person`.")
+// email is marked with usePercona="false"
+assert !buildLogText.contains("ADD email VARCHAR(255) NULL");
+
+
+File sql = new File( basedir, 'target/liquibase/migrate.sql' )
+assert sql.exists()
+def sqlText = sql.text
+assert sqlText.contains("pt-online-schema-change")
+assert sqlText.contains("pt-online-schema-change")
+assert !sqlText.contains("password=${config_password}")

--- a/src/main/java/liquibase/ext/percona/PerconaFormattedSqlChangeLogParser.java
+++ b/src/main/java/liquibase/ext/percona/PerconaFormattedSqlChangeLogParser.java
@@ -1,0 +1,81 @@
+package liquibase.ext.percona;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import liquibase.change.Change;
+import liquibase.change.core.RawSQLChange;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.exception.ChangeLogParseException;
+import liquibase.parser.core.formattedsql.FormattedSqlChangeLogParser;
+import liquibase.resource.ResourceAccessor;
+import liquibase.servicelocator.PrioritizedService;
+
+public class PerconaFormattedSqlChangeLogParser extends FormattedSqlChangeLogParser {
+    @Override
+    public int getPriority() {
+        return PrioritizedService.PRIORITY_DEFAULT + 50;
+    }
+
+    @Override
+    public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+        Pattern usePerconaPattern = Pattern.compile("(?im)^\\s*--liquibasePercona:usePercona=\"(false|true)\"\\s*$");
+        Pattern perconaOptionsPattern = Pattern.compile("(?im)^\\s*--liquibasePercona:perconaOptions=\"(.*)\"\\s*$");
+
+        DatabaseChangeLog changeLog = super.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+
+        for (int i = 0; i < changeLog.getChangeSets().size(); i++) {
+            ChangeSet changeSet = changeLog.getChangeSets().get(i);
+
+            ChangeSet perconaChangeSet = new ChangeSet(changeSet.getId(), changeSet.getAuthor(), changeSet.isAlwaysRun(),
+                    changeSet.isRunOnChange(), changeSet.getFilePath(), changeSet.getContextFilter().toString(),
+                    changeSet.getDbmsSet() == null ? null : changeSet.getDbmsSet().stream().collect(Collectors.joining(",")),
+                    changeSet.getRunWith(), changeSet.isRunInTransaction(), changeSet.getObjectQuotingStrategy(),
+                    changeLog);
+
+            for (Change change : changeSet.getChanges()) {
+                RawSQLChange rawSQLChange = (RawSQLChange) change;
+                PerconaRawSQLChange perconaChange = new PerconaRawSQLChange();
+                perconaChange.setSql(rawSQLChange.getSql());
+                perconaChange.setSplitStatements(rawSQLChange.isSplitStatements());
+                perconaChange.setStripComments(rawSQLChange.isStripComments());
+                perconaChange.setEndDelimiter(rawSQLChange.getEndDelimiter());
+                perconaChange.setRerunnable(rawSQLChange.isRerunnable());
+                perconaChange.setComment(rawSQLChange.getComment());
+                perconaChange.setDbms(rawSQLChange.getDbms());
+                perconaChangeSet.addChange(perconaChange);
+
+                String sql = perconaChange.getSql();
+                Matcher usePerconaMatcher = usePerconaPattern.matcher(sql);
+                if (usePerconaMatcher.find()) {
+                    perconaChange.setUsePercona(Boolean.valueOf(usePerconaMatcher.group(1)));
+                }
+
+                Matcher perconaOptionsMatcher = perconaOptionsPattern.matcher(sql);
+                if (perconaOptionsMatcher.find()) {
+                    perconaChange.setPerconaOptions(perconaOptionsMatcher.group(1));
+                }
+            }
+            changeLog.getChangeSets().set(i, perconaChangeSet);
+        }
+
+        return changeLog;
+    }
+}

--- a/src/main/java/liquibase/ext/percona/PerconaFormattedSqlChangeLogParser.java
+++ b/src/main/java/liquibase/ext/percona/PerconaFormattedSqlChangeLogParser.java
@@ -36,8 +36,8 @@ public class PerconaFormattedSqlChangeLogParser extends FormattedSqlChangeLogPar
 
     @Override
     public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
-        Pattern usePerconaPattern = Pattern.compile("(?im)^\\s*--liquibasePercona:usePercona=\"(false|true)\"\\s*$");
-        Pattern perconaOptionsPattern = Pattern.compile("(?im)^\\s*--liquibasePercona:perconaOptions=\"(.*)\"\\s*$");
+        Pattern usePerconaPattern = Pattern.compile("(?im)^\\s*\\-\\-\\s*liquibasePercona:usePercona=\"(false|true)\"\\s*$");
+        Pattern perconaOptionsPattern = Pattern.compile("(?im)^\\s*\\-\\-\\s*liquibasePercona:perconaOptions=\"(.*)\"\\s*$");
 
         DatabaseChangeLog changeLog = super.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
 

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -100,6 +100,10 @@ public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
         if (sql == null) {
             return null;
         }
+        if (Boolean.FALSE.equals(getUsePercona())) {
+            // avoids unnecessary warnings
+            return null;
+        }
 
         String[] multiLineSQL = StringUtil.processMultiLineSQL(sql, true, true, getEndDelimiter());
         if (multiLineSQL.length != 1) {

--- a/src/main/resources/META-INF/services/liquibase.parser.ChangeLogParser
+++ b/src/main/resources/META-INF/services/liquibase.parser.ChangeLogParser
@@ -1,0 +1,1 @@
+liquibase.ext.percona.PerconaFormattedSqlChangeLogParser

--- a/src/test/java/liquibase/ext/percona/ChangeLogParserTest.java
+++ b/src/test/java/liquibase/ext/percona/ChangeLogParserTest.java
@@ -44,16 +44,18 @@ public class ChangeLogParserTest {
 
     @BeforeEach
     public void setup() throws IOException {
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
 
         data.put("test-changelog.xml",
                 FileUtil.getContents(new File("src/test/resources/liquibase/ext/percona/changelog/test-changelog.xml")));
         data.put("test-changelog.yaml",
                 FileUtil.getContents(new File("src/test/resources/liquibase/ext/percona/changelog/test-changelog.yaml")));
+        data.put("test-changelog.sql",
+                FileUtil.getContents(new File("src/test/resources/liquibase/ext/percona/changelog/test-changelog.sql")));
         data.put("raw.githubusercontent.com/liquibase/liquibase-percona/liquibase-percona-2.0.0/src/main/resources/dbchangelog-ext-liquibase-percona.xsd",
                 FileUtil.getContents(new File("src/main/resources/dbchangelog-ext-liquibase-percona.xsd")));
-        data.put("www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd",
-                readLiquibaseSchema("www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd"));
+        data.put("www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd",
+                readLiquibaseSchema("www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"));
 
         resourceAccessor = new MockResourceAccessor(data);
     }
@@ -109,5 +111,17 @@ public class ChangeLogParserTest {
     public void testReadLiquibaseUsePerconaFlagXML() throws Exception {
         DatabaseChangeLog changelog = loadChangeLog("test-changelog.xml");
         assertChangeLog(changelog);
+    }
+
+    @Test
+    public void testReadLiquibaseUsePerconaFlagSQL() throws Exception {
+        DatabaseChangeLog changelog = loadChangeLog("test-changelog.sql");
+        Assertions.assertEquals(3, changelog.getChangeSets().size());
+        Change change = changelog.getChangeSets().get(0).getChanges().get(0);
+        assertChange(change, PerconaRawSQLChange.class, null, null);
+        change = changelog.getChangeSets().get(1).getChanges().get(0);
+        assertChange(change, PerconaRawSQLChange.class, Boolean.FALSE, null);
+        change = changelog.getChangeSets().get(2).getChanges().get(0);
+        assertChange(change, PerconaRawSQLChange.class, null, "--foo");
     }
 }

--- a/src/test/resources/liquibase/ext/percona/changelog/test-changelog.sql
+++ b/src/test/resources/liquibase/ext/percona/changelog/test-changelog.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset Alice:1
+CREATE TABLE person (name VARCHAR(255) NOT NULL, CONSTRAINT PK_PERSON PRIMARY KEY (name));
+
+--changeset Alice:2
+--liquibasePercona:usePercona="false"
+ALTER TABLE person ADD address VARCHAR(255) NULL;
+
+--changeset Alice:3
+--liquibasePercona:perconaOptions="--foo"
+ALTER TABLE person ADD email VARCHAR(255) NULL;

--- a/src/test/resources/liquibase/ext/percona/changelog/test-changelog.sql
+++ b/src/test/resources/liquibase/ext/percona/changelog/test-changelog.sql
@@ -8,5 +8,5 @@ CREATE TABLE person (name VARCHAR(255) NOT NULL, CONSTRAINT PK_PERSON PRIMARY KE
 ALTER TABLE person ADD address VARCHAR(255) NULL;
 
 --changeset Alice:3
---liquibasePercona:perconaOptions="--foo"
+-- liquibasePercona:perconaOptions="--foo"
 ALTER TABLE person ADD email VARCHAR(255) NULL;

--- a/src/test/resources/liquibase/ext/percona/changelog/test-changelog.xml
+++ b/src/test/resources/liquibase/ext/percona/changelog/test-changelog.xml
@@ -6,7 +6,7 @@
         xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
         xmlns:liquibasePercona="http://www.liquibase.org/xml/ns/dbchangelog-ext/liquibase-percona"
         xsi:schemaLocation="
-            http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd
+            http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
             http://www.liquibase.org/xml/ns/dbchangelog-ext/liquibase-percona https://raw.githubusercontent.com/liquibase/liquibase-percona/liquibase-percona-2.0.0/src/main/resources/dbchangelog-ext-liquibase-percona.xsd">
 
     <changeSet id="1" author="Alice">


### PR DESCRIPTION
### Support for Formatted SQL Changelogs

You can now use [Formatted SQL Changelogs](https://docs.liquibase.com/concepts/changelogs/sql-format.html). It also supports the `usePercona` flag.

The implementation reuses the support for Custom SQL changes. This means, that the same limitations apply to SQL Changelogs: Multiple statements are not supported. Only `ALTER TABLE` statements are executed with Percona Toolkit's `pt-online-schema-change`.

| :warning:    Support for SQL Changelogs is enabled by default. <br> If you apply a SQL changelog with Liquibase Percona extension, then it will try to execute all changeset with Percona Toolkit if possible. If this is not what you want, you need to make use of the [UsePercona flag](https://github.com/liquibase/liquibase-percona#usepercona-flag). You can also globally disable Percona Toolkit usage with the system property `liquibase.percona.defaultOn` and enable it for specific changes only. See [System Properties](https://github.com/liquibase/liquibase-percona#system-properties). |
|-----|

Example usage:

```sql
--changeset Alice:2
ALTER TABLE person ADD address VARCHAR(255) NULL;

--changeset Alice:3
--liquibasePercona:usePercona="false"
ALTER TABLE person ADD address VARCHAR(255) NULL;
```

- Fixes #287

Note: This PR depends on #291 