### PR TITLE
Set server_id=1 for MySQL in integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
   integration-tests:
     name: Java ${{ matrix.java }}, MySQL ${{ matrix.mysql }}, MariaDB ${{ matrix.mariadb }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         java: [8, 11, 17]
@@ -39,6 +40,7 @@ jobs:
   snapshot-deploy:
     name: Deploy Snapshot to Sonatype
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: ${{ github.repository == 'liquibase/liquibase-percona' && github.ref == 'refs/heads/main' }}
     needs: integration-tests
     steps:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,6 +12,7 @@ jobs:
   setup:
     name: Prepare Versions and Create Tag
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       extensionVersion: ${{ steps.determine_version.outputs.extensionVersion }}
       liquibaseVersion: ${{ steps.determine_version.outputs.liquibaseVersion }}
@@ -70,6 +71,7 @@ jobs:
     needs: setup
     name: "Build and Unit Test"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -106,6 +108,7 @@ jobs:
     needs: setup
     name: Java ${{ matrix.java }}, MySQL ${{ matrix.mysql }}, MariaDB ${{ matrix.mariadb }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         java: [8, 11, 17]
@@ -141,6 +144,7 @@ jobs:
   draft-release:
     needs: [setup, build, integration-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,6 +13,7 @@ jobs:
   integration-test:
     name: Java ${{ matrix.java }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         java: [8]

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,6 +7,7 @@ on:
 jobs:
     release:
       runs-on: ubuntu-latest
+      timeout-minutes: 60
       steps:
         - uses: actions/checkout@v4
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -455,6 +455,14 @@
                                         <env>
                                             <MYSQL_ROOT_PASSWORD>${config_password}</MYSQL_ROOT_PASSWORD>
                                         </env>
+                                        <cmd>
+                                            <exec>
+                                                <!-- set server_id to 1 for mysql 5.7 and percona-toolkit 3.5.5, see https://jira.percona.com/browse/PT-2268
+                                                Note: mysql 8.0 and mariadb use by default server_id=1, only mysql 5.7 uses server_id=0 as default.
+                                                -->
+                                                <arg>--server-id=1</arg>
+                                            </exec>
+                                        </cmd>
                                         <containerNamePattern>%a</containerNamePattern>
                                         <network>
                                             <mode>bridge</mode>


### PR DESCRIPTION
The latest percona toolkit 3.5.5 contains a change, which makes the toolkit hang when determining the server id (https://jira.percona.com/browse/PT-2268).

The server_id for MySQL 5.7 is 0 by default (https://dev.mysql.com/doc/refman/5.7/en/replication-options.html#sysvar_server_id). For MySQL 8.0 it is 1 (https://dev.mysql.com/doc/refman/8.0/en/replication-options.html#sysvar_server_id) and for MariaDB it is 1 since 10.2.1 (https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#server_id).

This PR sets the server_id to 1 when starting the MySQL docker containers.

Additionally timeouts of 60 minutes (instead of the default 360 minutes) are used for the github job runs.