### PR TITLE
Update MySQL and MariaDB versions for integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         java: [8, 11, 17]
         mysql: [5.7, 8]
-        mariadb: [10]
+        mariadb: [10, 11]
     steps:
     - uses: actions/checkout@v4
     - name: Install Perl modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         java: [8, 11, 17]
-        mysql: [5.7, 8]
+        mysql: [8.0, 8.2]
         mariadb: [10, 11]
     steps:
     - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <java.version>1.8</java.version>
         <liquibase.version>4.25.0</liquibase.version>
-        <mysql.version>8.0.30</mysql.version>
+        <mysql.connector.version>8.2.0</mysql.connector.version>
         <mariadb.connector.version>3.2.0</mariadb.connector.version>
         <percona.toolkit.version>3.5.5</percona.toolkit.version>
 
@@ -90,9 +90,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql.version}</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.connector.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <config_password>root</config_password>
         <config_dbname>testdb</config_dbname>
         <mysql_image>mysql:5.7</mysql_image>
-        <mariadb_image>mariadb:10</mariadb_image>
+        <mariadb_image>mariadb:11</mariadb_image>
 
         <docker.removeVolumes>true</docker.removeVolumes>
         <percona.toolkit.usecache>true</percona.toolkit.usecache>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <config_user>root</config_user>
         <config_password>root</config_password>
         <config_dbname>testdb</config_dbname>
-        <mysql_image>mysql:5.7</mysql_image>
+        <mysql_image>mysql:8.2</mysql_image>
         <mariadb_image>mariadb:11</mariadb_image>
 
         <docker.removeVolumes>true</docker.removeVolumes>

--- a/src/it/addColumn/pom.xml
+++ b/src/it/addColumn/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnCrossDatabase/pom.xml
+++ b/src/it/addColumnCrossDatabase/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnDefaultOff/pom.xml
+++ b/src/it/addColumnDefaultOff/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnFailIfNoPT/pom.xml
+++ b/src/it/addColumnFailIfNoPT/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnNotUsePerconaXml/pom.xml
+++ b/src/it/addColumnNotUsePerconaXml/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnNotUsePerconaYaml/pom.xml
+++ b/src/it/addColumnNotUsePerconaYaml/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnSqlChangelog/pom.xml
+++ b/src/it/addColumnSqlChangelog/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnWithAdditionalOptions/pom.xml
+++ b/src/it/addColumnWithAdditionalOptions/pom.xml
@@ -49,9 +49,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnWithConstraintSelf/pom.xml
+++ b/src/it/addColumnWithConstraintSelf/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnWithConstraints/pom.xml
+++ b/src/it/addColumnWithConstraints/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnWithPerconaOptionsXml/pom.xml
+++ b/src/it/addColumnWithPerconaOptionsXml/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnWithPerconaOptionsYaml/pom.xml
+++ b/src/it/addColumnWithPerconaOptionsYaml/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnWithRollback/pom.xml
+++ b/src/it/addColumnWithRollback/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addColumnWithRollbackSqlChangelog/pom.xml
+++ b/src/it/addColumnWithRollbackSqlChangelog/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addForeignKeyConstraint/pom.xml
+++ b/src/it/addForeignKeyConstraint/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addForeignKeyConstraintSelf/pom.xml
+++ b/src/it/addForeignKeyConstraintSelf/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addPrimaryKeyNew/pom.xml
+++ b/src/it/addPrimaryKeyNew/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addPrimaryKeyWithDrop/pom.xml
+++ b/src/it/addPrimaryKeyWithDrop/pom.xml
@@ -49,9 +49,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/addUniqueConstraint/pom.xml
+++ b/src/it/addUniqueConstraint/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/allChangesLiquibaseLatest/pom.xml
+++ b/src/it/allChangesLiquibaseLatest/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/allChangesLiquibaseLatestToolkit/pom.xml
+++ b/src/it/allChangesLiquibaseLatestToolkit/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/allChangesLiquibaseMySQL8/pom.xml
+++ b/src/it/allChangesLiquibaseMySQL8/pom.xml
@@ -30,9 +30,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/connectionTimeout/pom.xml
+++ b/src/it/connectionTimeout/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/createIndex/pom.xml
+++ b/src/it/createIndex/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/createIndexPrefix/pom.xml
+++ b/src/it/createIndexPrefix/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/createIndexSkipped/pom.xml
+++ b/src/it/createIndexSkipped/pom.xml
@@ -49,9 +49,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/createIndexWithRollback/pom.xml
+++ b/src/it/createIndexWithRollback/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/dropForeignKeyConstraint/pom.xml
+++ b/src/it/dropForeignKeyConstraint/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/dropIndex/pom.xml
+++ b/src/it/dropIndex/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/dropUniqueConstraint/pom.xml
+++ b/src/it/dropUniqueConstraint/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/dropcolumn/pom.xml
+++ b/src/it/dropcolumn/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/modifyDataTypeChange/pom.xml
+++ b/src/it/modifyDataTypeChange/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/rawSql/pom.xml
+++ b/src/it/rawSql/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/it/rollbackForeignKeyConstraint/pom.xml
+++ b/src/it/rollbackForeignKeyConstraint/pom.xml
@@ -29,9 +29,9 @@
                         <version>@project.version@</version>
                     </dependency>
                     <dependency>
-                        <groupId>mysql</groupId>
-                        <artifactId>mysql-connector-java</artifactId>
-                        <version>@mysql.version@</version>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <version>@mysql.connector.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
By default, MariaDB 11 will be tested. GitHub Action Integration Test will additionally run against MariaDB 10.

By default, MySQL 8.2 will be tested. GitHub Action Integration Test will additionally run against MySQL 8.0.

Also update mysql-connector-j from 8.0.30 to latest 8.2.0.
