### PR TITLE
Fix integration test (addColumnFailIfNoPT)

### DIFF
--- a/src/it/addColumnFailIfNoPT/verify.groovy
+++ b/src/it/addColumnFailIfNoPT/verify.groovy
@@ -22,4 +22,5 @@ import java.sql.ResultSet;
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
 def buildLogText = buildLog.text;
-assert buildLogText.contains("[ERROR] liquibase.exception.ChangeLogParseException: liquibase.exception.UnexpectedLiquibaseException: No percona toolkit found!")
+assert buildLogText.contains("ValidationFailedException")
+assert buildLogText.contains("No percona toolkit found!")

--- a/src/main/java/liquibase/ext/percona/PerconaAddColumnChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaAddColumnChange.java
@@ -34,6 +34,7 @@ import liquibase.change.core.DropDefaultValueChange;
 import liquibase.database.Database;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 
 /**
@@ -233,6 +234,11 @@ public class PerconaAddColumnChange extends AddColumnChange implements PerconaCh
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaAddForeignKeyConstraintChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaAddForeignKeyConstraintChange.java
@@ -25,6 +25,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.AddForeignKeyConstraintChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.util.StringUtil;
 
@@ -157,6 +158,11 @@ public class PerconaAddForeignKeyConstraintChange extends AddForeignKeyConstrain
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaAddPrimaryKeyChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaAddPrimaryKeyChange.java
@@ -26,6 +26,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.AddPrimaryKeyChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.util.StringUtil;
 
@@ -123,6 +124,11 @@ public class PerconaAddPrimaryKeyChange extends AddPrimaryKeyChange implements P
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaAddUniqueConstraintChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaAddUniqueConstraintChange.java
@@ -25,6 +25,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.AddUniqueConstraintChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.util.StringUtil;
 
@@ -134,6 +135,11 @@ public class PerconaAddUniqueConstraintChange extends AddUniqueConstraintChange 
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaChangeUtil.java
+++ b/src/main/java/liquibase/ext/percona/PerconaChangeUtil.java
@@ -126,10 +126,12 @@ public class PerconaChangeUtil {
     public static ValidationErrors validate(ValidationErrors validationErrors, Database database) {
         // Note: MariaDB is a subclass of MySQLDatabase - so the Percona changes are
         // used for both MySQLDatabase and MariaDBDatabase.
-        if (database instanceof MySQLDatabase
-                && !PTOnlineSchemaChangeStatement.isAvailable()
-                && Configuration.failIfNoPT()) {
-            validationErrors.addError("No percona toolkit found!");
+        if (database instanceof MySQLDatabase && !PTOnlineSchemaChangeStatement.isAvailable()) {
+            if (Configuration.failIfNoPT()) {
+                validationErrors.addError("No percona toolkit found!");
+            } else {
+                validationErrors.addWarning("Not using percona toolkit, because it is not available!");
+            }
         }
         return validationErrors;
     }

--- a/src/main/java/liquibase/ext/percona/PerconaChangeUtil.java
+++ b/src/main/java/liquibase/ext/percona/PerconaChangeUtil.java
@@ -27,7 +27,7 @@ import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.exception.DatabaseException;
-import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.exception.ValidationErrors;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
@@ -116,14 +116,22 @@ public class PerconaChangeUtil {
                     statements.add(statement);
                 }
             } else {
-                if (Configuration.failIfNoPT()) {
-                    throw new UnexpectedLiquibaseException("No percona toolkit found!");
-                }
                 maybeLog("Not using percona toolkit, because it is not available!");
             }
         }
 
         return statements.toArray(new SqlStatement[statements.size()]);
+    }
+
+    public static ValidationErrors validate(ValidationErrors validationErrors, Database database) {
+        // Note: MariaDB is a subclass of MySQLDatabase - so the Percona changes are
+        // used for both MySQLDatabase and MariaDBDatabase.
+        if (database instanceof MySQLDatabase
+                && !PTOnlineSchemaChangeStatement.isAvailable()
+                && Configuration.failIfNoPT()) {
+            validationErrors.addError("No percona toolkit found!");
+        }
+        return validationErrors;
     }
 
     /**

--- a/src/main/java/liquibase/ext/percona/PerconaCreateIndexChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaCreateIndexChange.java
@@ -27,6 +27,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.CreateIndexChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 
 @DatabaseChange(name = PerconaCreateIndexChange.NAME,
@@ -145,6 +146,11 @@ public class PerconaCreateIndexChange extends CreateIndexChange implements Perco
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaDropColumnChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaDropColumnChange.java
@@ -24,6 +24,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.DropColumnChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 
 /**
@@ -121,6 +122,11 @@ public class PerconaDropColumnChange extends DropColumnChange implements Percona
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaDropForeignKeyConstraintChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaDropForeignKeyConstraintChange.java
@@ -23,6 +23,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.DropForeignKeyConstraintChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 
 /**
@@ -112,6 +113,11 @@ public class PerconaDropForeignKeyConstraintChange extends DropForeignKeyConstra
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaDropIndexChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaDropIndexChange.java
@@ -23,6 +23,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.DropIndexChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 
 @DatabaseChange(name = PerconaDropIndexChange.NAME,
@@ -103,6 +104,11 @@ public class PerconaDropIndexChange extends DropIndexChange implements PerconaCh
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaDropUniqueConstraintChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaDropUniqueConstraintChange.java
@@ -23,6 +23,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.DropUniqueConstraintChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 
 /**
@@ -110,6 +111,11 @@ public class PerconaDropUniqueConstraintChange extends DropUniqueConstraintChang
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaModifyDataTypeChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaModifyDataTypeChange.java
@@ -24,6 +24,7 @@ import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.ModifyDataTypeChange;
 import liquibase.database.Database;
 import liquibase.datatype.DataTypeFactory;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 
 
@@ -106,6 +107,11 @@ public class PerconaModifyDataTypeChange extends ModifyDataTypeChange implements
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
+++ b/src/main/java/liquibase/ext/percona/PerconaRawSQLChange.java
@@ -24,6 +24,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
 import liquibase.change.core.RawSQLChange;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.logging.Logger;
 import liquibase.statement.SqlStatement;
 import liquibase.util.StringUtil;
@@ -203,6 +204,11 @@ public class PerconaRawSQLChange extends RawSQLChange implements PerconaChange {
         fields.remove("usePercona");
         fields.remove("perconaOptions");
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return PerconaChangeUtil.validate(super.validate(database), database);
     }
     //CPD-ON
 }

--- a/src/test/java/liquibase/ext/percona/AbstractPerconaChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/AbstractPerconaChangeTest.java
@@ -28,6 +28,7 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.exception.RollbackImpossibleException;
+import liquibase.exception.ValidationErrors;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
 import liquibase.executor.jvm.JdbcExecutor;
@@ -120,6 +121,10 @@ public abstract class AbstractPerconaChangeTest<T extends PerconaChange> {
     }
     protected SqlStatement[] generateRollbackStatements() throws RollbackImpossibleException {
         return change.generateRollbackStatements(database);
+    }
+
+    protected ValidationErrors validate() {
+        return change.validate(database);
     }
 
     protected void enableLogging() {

--- a/src/test/java/liquibase/ext/percona/PerconaAddColumnChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaAddColumnChangeTest.java
@@ -22,6 +22,7 @@ import liquibase.change.AddColumnConfig;
 import liquibase.change.ConstraintsConfig;
 import liquibase.database.Database;
 import liquibase.exception.RollbackImpossibleException;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddColumnStatement;
 import liquibase.statement.core.CommentStatement;
@@ -66,25 +67,9 @@ public class PerconaAddColumnChangeTest extends AbstractPerconaChangeTest<Percon
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
-    }
-
-    @Test
-    public void testWithoutPerdatabaseconaRollbackAndFail() throws RollbackImpossibleException {
-        System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
-        PTOnlineSchemaChangeStatement.available = false;
-
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateRollbackStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertEquals("No percona toolkit found!", errors.getErrorMessages().get(0));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaAddForeignKeyConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaAddForeignKeyConstraintChangeTest.java
@@ -16,9 +16,9 @@ package liquibase.ext.percona;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import liquibase.exception.RollbackImpossibleException;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddForeignKeyConstraintStatement;
 import liquibase.statement.core.CommentStatement;
@@ -71,25 +71,9 @@ public class PerconaAddForeignKeyConstraintChangeTest extends AbstractPerconaCha
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
-    }
-
-    @Test
-    public void testWithoutPerdatabaseconaRollbackAndFail() throws RollbackImpossibleException {
-        System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
-        PTOnlineSchemaChangeStatement.available = false;
-
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateRollbackStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertTrue(errors.getErrorMessages().contains("No percona toolkit found!"));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaAddPrimaryKeyChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaAddPrimaryKeyChangeTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import liquibase.exception.RollbackImpossibleException;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddPrimaryKeyStatement;
 import liquibase.statement.core.CommentStatement;
@@ -62,12 +63,9 @@ public class PerconaAddPrimaryKeyChangeTest extends AbstractPerconaChangeTest<Pe
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertEquals("No percona toolkit found!", errors.getErrorMessages().get(0));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaAddUniqueConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaAddUniqueConstraintChangeTest.java
@@ -16,9 +16,9 @@ package liquibase.ext.percona;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import liquibase.exception.RollbackImpossibleException;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddUniqueConstraintStatement;
 import liquibase.statement.core.CommentStatement;
@@ -65,25 +65,9 @@ public class PerconaAddUniqueConstraintChangeTest extends AbstractPerconaChangeT
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
-    }
-
-    @Test
-    public void testWithoutPerdatabaseconaRollbackAndFail() throws RollbackImpossibleException {
-        System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
-        PTOnlineSchemaChangeStatement.available = false;
-
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateRollbackStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertEquals("No percona toolkit found!", errors.getErrorMessages().get(0));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaDropColumnChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaDropColumnChangeTest.java
@@ -16,9 +16,9 @@ package liquibase.ext.percona;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import liquibase.change.ColumnConfig;
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.CommentStatement;
 import liquibase.statement.core.DropColumnStatement;
@@ -68,12 +68,9 @@ public class PerconaDropColumnChangeTest extends AbstractPerconaChangeTest<Perco
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertEquals("No percona toolkit found!", errors.getErrorMessages().get(0));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaDropForeignKeyConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaDropForeignKeyConstraintChangeTest.java
@@ -16,8 +16,8 @@ package liquibase.ext.percona;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.CommentStatement;
 import liquibase.statement.core.DropForeignKeyConstraintStatement;
@@ -50,12 +50,9 @@ public class PerconaDropForeignKeyConstraintChangeTest extends AbstractPerconaCh
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertEquals("No percona toolkit found!", errors.getErrorMessages().get(0));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaDropUniqueConstraintChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaDropUniqueConstraintChangeTest.java
@@ -16,8 +16,8 @@ package liquibase.ext.percona;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.CommentStatement;
 import liquibase.statement.core.DropUniqueConstraintStatement;
@@ -49,12 +49,9 @@ public class PerconaDropUniqueConstraintChangeTest extends AbstractPerconaChange
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertEquals("No percona toolkit found!", errors.getErrorMessages().get(0));
     }
 
     @Test

--- a/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
+++ b/src/test/java/liquibase/ext/percona/PerconaRawSQLChangeTest.java
@@ -16,8 +16,8 @@ package liquibase.ext.percona;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
+import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.CommentStatement;
 import liquibase.statement.core.RawSqlStatement;
@@ -173,12 +173,9 @@ public class PerconaRawSQLChangeTest extends AbstractPerconaChangeTest<PerconaRa
         System.setProperty(Configuration.FAIL_IF_NO_PT, "true");
         PTOnlineSchemaChangeStatement.available = false;
 
-        Assertions.assertThrows(RuntimeException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                generateStatements();
-            }
-        });
+        ValidationErrors errors = validate();
+        Assertions.assertTrue(errors.hasErrors());
+        Assertions.assertEquals("No percona toolkit found!", errors.getErrorMessages().get(0));
     }
 
     @Test


### PR DESCRIPTION
This changes the way, how a missing percona toolkit is reported.
Previously just a UnexpectedLiquibaseException was thrown, now the existence of percona toolkit is tested via `validate()`.

If percona toolkit is missing and liquibase-percona should fail, then a validation error is reported. Otherwise just a warning.
