### PR TITLE
chore: Use https for scm connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <system>github</system>
     </issueManagement>
     <scm>
-        <connection>scm:git:http://github.com/liquibase/liquibase-percona.git</connection>
+        <connection>scm:git:https://github.com/liquibase/liquibase-percona.git</connection>
         <url>https://github.com/liquibase/liquibase-percona</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
This hopefully fixes the release workflow.

The [last release](https://github.com/liquibase/liquibase-percona/actions/runs/8457903698) failed with:

```
[INFO] Executing: /bin/sh -c cd /home/runner/work/liquibase-percona/liquibase-percona && git push http://github.com/liquibase/liquibase-percona.git refs/heads/main:refs/heads/main
[INFO] Working directory: /home/runner/work/liquibase-percona/liquibase-percona
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.805 s
[INFO] Finished at: 2024-03-27T20:26:57Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project liquibase-percona: Unable to commit files
Error:  Provider message:
Error:  The git-push command failed.
Error:  Command output:
Error:  fatal: could not read Username for 'https://github.com/': No such device or address
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error: Process completed with exit code 1.
```
