### PR TITLE
build: Run integration tests against mysql 8.0 and 8.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         java: [8, 11, 17, 21]
-        mysql: [8.0, 8.2]
+        mysql: ["8.0", "8.2"]
         mariadb: [10, 11]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This should fix the integration tests.

Percona Toolkit is not compatible yet with MySQL 8.4 (e.g. the `SHOW SLAVE HOSTS` has been removed in favor of `SHOW REPLICAS`).

The current build script was using mysql:8 instead of mysql:8.0, so that latest mysql:8 was used...
