### PR TITLE
build(deps): bump liquibase/build-logic from 0.7.8 to main

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@main
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - run: true
 
   build-test:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     needs: authorize
     secrets: inherit
     with:
@@ -56,5 +56,5 @@ jobs:
 
   dependabot-automerge:
     needs: integration-tests
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
     secrets: inherit


### PR DESCRIPTION
Because:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/download-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
