### PR TITLE
chore: wait for log output when starting mysql/mariadb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -587,6 +587,7 @@
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <configuration>
+<!--                            <showLogs>true</showLogs>-->
                             <images>
                                 <image>
                                     <name>${mysql_image}</name>
@@ -611,11 +612,7 @@
                                             <port>config_port:3306</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <ports>
-                                                    <port>3306</port>
-                                                </ports>
-                                            </tcp>
+                                            <log>port: 3306</log>
                                             <time>180000</time>
                                         </wait>
                                     </run>
@@ -635,11 +632,7 @@
                                             <port>config_port_mariadb:3306</port>
                                         </ports>
                                         <wait>
-                                            <tcp>
-                                                <ports>
-                                                    <port>3306</port>
-                                                </ports>
-                                            </tcp>
+                                            <log>port: 3306</log>
                                             <time>180000</time>
                                         </wait>
                                     </run>


### PR DESCRIPTION
Waiting for the port stopped working for me,
as no direct access to the container is possible anymore due to firewall.