### PR TITLE
build: execute verify lifecycle for "build-test"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       java: "[11, 17, 21]"
       os: '["ubuntu-latest", "windows-latest"]'
+      extraMavenArgs: 'verify'
 
   integration-tests:
     name: Java ${{ matrix.java }}, MySQL ${{ matrix.mysql }}, MariaDB ${{ matrix.mariadb }}


### PR DESCRIPTION
This should find problems from PMD/Spotbugs before trying to run the integration tests.