### PR TITLE
Bump maven-release-plugin to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,10 @@
                     <version>3.26.0</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.1.1</version> <!-- for reproducible builds: >= 3.0.0-M1 -->
+                </plugin>
+                <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                 </plugin>


### PR DESCRIPTION
This is needed to properly support reproducible builds. Only the newer versions will update project.build.outputTimestamp.