### PR TITLE
DAT-20361   GitHub Secrets Migration

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -11,6 +11,7 @@ permissions:
   actions: read
   packages: write
   pull-requests: write
+  id-token: write
 
 jobs:
   dry-run-attach-artifact-to-release:

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -26,12 +26,27 @@ jobs:
     outputs:
       dry_run_release_id: ${{ steps.get_draft_release_id.outputs.release_id }}
     steps:
+
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
       - name: Get GitHub App token
         id: get-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           
       - name: Get Draft Release ID
@@ -78,12 +93,26 @@ jobs:
       - name: Checkout liquibase
         uses: actions/checkout@v4
 
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
       - name: Get GitHub App token
         id: get-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: read
 
@@ -117,6 +146,20 @@ jobs:
         cleanup,
       ]
     steps:
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
       - name: Notify Slack on Build Failure
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -124,7 +167,7 @@ jobs:
           SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} <@U040C8J8143> <@U04P39MS2SW> <@UHHJ6UAEQ> <@U042HRTL4DT>" # Jandro, Sailee, Jake, Filipe
           SLACK_TITLE: "❌ ${{ github.repository }} ❌ Build failed on branch ${{ github.ref }} for commit ${{ github.sha }} in repository ${{github.repository}}"
           SLACK_USERNAME: liquibot
-          SLACK_WEBHOOK: ${{ secrets.DRY_RUN_RELEASE_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ env.DRY_RUN_RELEASE_SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":robot_face:"
           SLACK_FOOTER: "${{ github.repository }}"
           SLACK_LINK_NAMES: true

--- a/.github/workflows/manual-release-from-tag.yml
+++ b/.github/workflows/manual-release-from-tag.yml
@@ -29,6 +29,20 @@ jobs:
           distribution: "temurin"
           cache: "maven"
 
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-release-published.yml
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22
@@ -73,27 +87,36 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "sonatype-nexus-staging",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_TOKEN }}"
+                "username": "${{ env.SONATYPE_USERNAME }}",
+                "password": "${{ env.SONATYPE_TOKEN }}"
               }
             ]
+
+      - name: Convert escaped newlines and set GPG key
+        run: |
+          {
+            echo "GPG_KEY_CONTENT<<GPG_EOF"
+            printf '%b' "${{ env.GPG_SECRET }}"
+            echo
+            echo "GPG_EOF"
+          } >> $GITHUB_ENV
 
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-attach-artifact-release.yml
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg_private_key: ${{ secrets.GPG_SECRET }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ env.GPG_KEY_CONTENT }}
+          passphrase: ${{ env.GPG_PASSPHRASE }}
 
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-attach-artifact-release.yml
       - name: Build release artifacts


### PR DESCRIPTION
This pull request updates multiple GitHub Actions workflows to enhance security and streamline secret management by transitioning from `secrets` to `env` variables and integrating AWS Secrets Manager for retrieving sensitive data. Additionally, it includes improvements for handling GPG keys in the manual release workflow.

### Enhancements to Secret Management:
* Updated workflows (`.github/workflows/dry-run-release.yml`, `.github/workflows/manual-release-from-tag.yml`) to replace the use of `secrets` with `env` variables for sensitive data such as GitHub App credentials, Slack webhook URLs, and other tokens. This change improves flexibility and aligns with best practices for environment variable usage. [[1]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR29-R49) [[2]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR96-R115) [[3]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR149-R170) [[4]](diffhunk://#diff-4921a56a453616b739e57c149f7e77fd0f21026ea4ce15ae7f1c220d15b3eb94L76-R119)

* Integrated AWS Secrets Manager to retrieve secrets dynamically using the `aws-actions/aws-secretsmanager-get-secrets@v2` action. This ensures secure, centralized secret management and reduces hardcoded values in workflows. [[1]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR29-R49) [[2]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR96-R115) [[3]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR149-R170) [[4]](diffhunk://#diff-4921a56a453616b739e57c149f7e77fd0f21026ea4ce15ae7f1c220d15b3eb94R32-R45)

### Improvements for GPG Key Handling:
* Added a step in the manual release workflow (`.github/workflows/manual-release-from-tag.yml`) to convert escaped newlines in the GPG key and set it as an environment variable. This ensures proper formatting before importing the key.

* Updated the GPG key import step to use `env` variables for the private key and passphrase instead of `secrets`, improving consistency with other changes in the workflow.