### PR TITLE
Fix reusable workflow permissions (DAT-20361)

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -5,6 +5,12 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write
+  actions: read
+  packages: write
+  id-token: write
+
 jobs:
   attach-artifact-to-release:
     uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main


### PR DESCRIPTION
## Summary
- Add missing permissions section to attach-artifact-release.yml
- Ensures workflow permissions match build-logic/extension-attach-artifact-release.yml

## Test plan
- [ ] Verify workflow permissions match build-logic workflows  
- [ ] Test workflow execution after merge

🤖 Generated with [Claude Code](https://claude.ai/code)