### PR TITLE
DAT-21010: Add Java 25 to github builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: authorize
     secrets: inherit
     with:
-      java: "[11, 17, 21]"
+      java: "[11, 17, 21, 25]"
       os: '["ubuntu-latest", "windows-latest"]'
       extraMavenArgs: 'verify'
 
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [8, 11, 17, 21, 25]
         mysql: ["8.0", "8.4"]
         mariadb: [10, 11]
     steps:


### PR DESCRIPTION
This PR adds Java 25 to the matrix configuration for Java version testing in GitHub Actions workflows.

## Changes
- Updated workflow files to include Java 25 in the matrix strategy
- Ensures compatibility testing with Java 25 alongside existing versions (11, 17, 21)

## Related
- Jira Ticket: [DAT-21010](https://datical.atlassian.net/browse/DAT-21010)

🤖 Generated with [Claude Code](https://claude.com/claude-code)