### PR TITLE
Remove Java 8/11 from build and integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: authorize
     secrets: inherit
     with:
-      java: "[11, 17, 21, 25]"
+      java: "[17, 21, 25]"
       os: '["ubuntu-latest", "windows-latest"]'
       extraMavenArgs: 'verify'
 
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [8, 11, 17, 21, 25]
+        java: [17, 21, 25]
         mysql: ["8.0", "8.4"]
         mariadb: [10, 11]
     steps:


### PR DESCRIPTION
This is needed in preparation for Liquibase 5.
See also liquibase/liquibase#7216

And it is needed to be update to update spotbugs (see #608)