### PR TITLE
chore: reduce integration test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,23 @@ jobs:
     strategy:
       matrix:
         java: [17, 21, 25]
-        mysql: ["8.0", "8.4"]
-        mariadb: ["10.6", "10.11", "11.4", "11.8"]
+        mysql: ["8.4"]
+        mariadb: ["11.8"]
+        include:
+          # older mysql versions
+          - java: "25"
+            mysql: "8.0"
+            mariadb: "11.8"
+          # older mariadb versions
+          - java: "25"
+            mysql: "8.4"
+            mariadb: "11.4"
+          - java: "25"
+            mysql: "8.4"
+            mariadb: "10.11"
+          - java: "25"
+            mysql: "8.4"
+            mariadb: "10.6"
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
Now we only test the latest mysql/mariadb versions against java 17, 21, 25. This should be 3 jobs. Then we additionally test the older mysql version and the older mariadb versions only with java25. This should be additionally 4 jobs. So, we should have only 7 jobs in total instead of 24 jobs.