### PR TITLE
Fix: Add SSL flag (s=yes) to Percona DSN when useSSL=true

### DIFF
--- a/src/main/java/liquibase/ext/percona/DatabaseConnectionUtil.java
+++ b/src/main/java/liquibase/ext/percona/DatabaseConnectionUtil.java
@@ -47,12 +47,14 @@ public class DatabaseConnectionUtil {
     private final String port;
     private final String user;
     private final String password;
+    private final boolean isSsl;
 
     public DatabaseConnectionUtil(DatabaseConnection connection) {
         this.host = determineHost(connection.getURL());
         this.port = determinePort(connection.getURL());
         this.user = determineUser(connection.getConnectionUserName());
         this.password = determinePassword(connection);
+        this.isSsl = determineUseSsl(connection.getURL());
     }
 
     public String getHost() {
@@ -71,6 +73,10 @@ public class DatabaseConnectionUtil {
         return this.password;
     }
 
+    public boolean isSsl() {
+        return isSsl;
+    }
+
     private static String determineHost(String url) {
         Pattern p = Pattern.compile("jdbc:(?:mysql|mariadb):(?:replication:|loadbalance:|sequential:|aurora:)?//([^@]+@)?([^:/]+)");
         Matcher m = p.matcher(url);
@@ -87,6 +93,15 @@ public class DatabaseConnectionUtil {
             return m.group(1);
         }
         return "3306";
+    }
+
+    private static boolean determineUseSsl(String url) {
+        Pattern p = Pattern.compile("jdbc:(?:mysql|mariadb):(?:replication:|loadbalance:|sequential:|aurora:)?//.+?[?&]useSSL=([^&]+)");
+        Matcher m = p.matcher(url);
+        if (m.find()) {
+            return "true".equals(m.group(1));
+        }
+        return false;
     }
 
     private static String determineUser(String connectionUserName) {

--- a/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
+++ b/src/main/java/liquibase/ext/percona/PTOnlineSchemaChangeStatement.java
@@ -147,6 +147,9 @@ public class PTOnlineSchemaChangeStatement implements ExecutablePreparedStatemen
             dsn.append("h=").append(connection.getHost());
             dsn.append(",P=").append(connection.getPort());
             dsn.append(",u=").append(connection.getUser());
+            if (connection.isSsl()) {
+                dsn.append(",s=yes");
+            }
             dsn.append(',');
 
             String pw = connection.getPassword();

--- a/src/test/java/liquibase/ext/percona/DatabaseConnectionUtilTest.java
+++ b/src/test/java/liquibase/ext/percona/DatabaseConnectionUtilTest.java
@@ -20,8 +20,6 @@ import java.util.Properties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import liquibase.database.jvm.JdbcConnection;
@@ -61,7 +59,7 @@ public class DatabaseConnectionUtilTest {
 
         util = new DatabaseConnectionUtil(MockDatabaseConnection.fromUrl("jdbc:mariadb://127.0.0.1:3307/testdb"));
         Assertions.assertEquals("3307", util.getPort());
-}
+    }
 
     @Test
     public void testGetUser() {
@@ -144,5 +142,30 @@ public class DatabaseConnectionUtilTest {
         System.setProperty(Configuration.LIQUIBASE_PASSWORD, "password-via-system-property");
         DatabaseConnectionUtil util = new DatabaseConnectionUtil(MockDatabaseConnection.fromUrl("jdbc:mysql://user@localhost:3306/testdb"));
         Assertions.assertEquals("password-via-system-property", util.getPassword());
+    }
+
+    @Test
+    public void testDetermineUseSsl() {
+        DatabaseConnectionUtil util;
+
+        util = new DatabaseConnectionUtil(MockDatabaseConnection.fromUrl(
+                "jdbc:mysql://localhost:3306/testdb"));
+        Assertions.assertFalse(util.isSsl());
+
+        util = new DatabaseConnectionUtil(MockDatabaseConnection.fromUrl(
+                "jdbc:mysql://localhost/testdb?useSSL=true"));
+        Assertions.assertTrue(util.isSsl());
+
+        util = new DatabaseConnectionUtil(MockDatabaseConnection.fromUrl(
+                "jdbc:mariadb://localhost:3306/testdb?useSSL=true&allowPublicKeyRetrieval=true"));
+        Assertions.assertTrue(util.isSsl());
+
+        util = new DatabaseConnectionUtil(MockDatabaseConnection.fromUrl(
+                "jdbc:mysql://localhost/testdb?useSSL=false"));
+        Assertions.assertFalse(util.isSsl());
+
+        util = new DatabaseConnectionUtil(MockDatabaseConnection.fromUrl(
+                "jdbc:mariadb://localhost/testdb?allowPublicKeyRetrieval=true&useSSL=false"));
+        Assertions.assertFalse(util.isSsl());
     }
 }

--- a/src/test/java/liquibase/ext/percona/PTOnlineSchemaChangeStatementTest.java
+++ b/src/test/java/liquibase/ext/percona/PTOnlineSchemaChangeStatementTest.java
@@ -156,4 +156,16 @@ public class PTOnlineSchemaChangeStatementTest {
                 "[pt-online-schema-change, --arg1=val1 val2, --alter-foreign-keys-method=auto, --alter=ADD COLUMN new_column INT NULL, --password=root, --execute, h=localhost,P=3306,u=user,D=testdb,t=person]",
                 String.valueOf(statement.buildCommand(database)));
     }
+
+    @Test
+    public void testSslDsnOption() {
+        DatabaseConnection conn = new MockDatabaseConnection("jdbc:mysql://user@localhost:3306/testdb?useSSL=true&allowPublicKeyRetrieval=true",
+                "user@localhost");
+        database.setConnection(conn);
+        PTOnlineSchemaChangeStatement statement = new PTOnlineSchemaChangeStatement(database, "testdb", "person",
+                "ADD COLUMN new_column INT NULL", Optional.empty());
+        Assertions.assertEquals(
+                "[pt-online-schema-change, --alter-foreign-keys-method=auto, --nocheck-unique-key-change, --alter=ADD COLUMN new_column INT NULL, --password=root, --execute, h=localhost,P=3306,u=user,s=yes,D=testdb,t=person]",
+                String.valueOf(statement.buildCommand(database)));
+    }
 }


### PR DESCRIPTION
Percona Toolkit recently introduced support for passing ssl options through the DSN:
```
s
dsn: mysql_ssl; copy: yes
```

While testing MySQL 8+ connections with useSSL=true, we encountered an error with error code 18. After debugging, we found that Percona Toolkit requires the ssl flag s=yes in the DSN to properly establish an SSL-enabled connection.

What This PR Does

This PR enhances liquibase-percona to automatically include s=yes in the generated DSN whenever the JDBC URL contains useSSL=true. This ensures MySQL 8+ connections work correctly when SSL is enabled and avoids error.