### PR TITLE
chore: Migrate Windows runners to Blacksmith for cost and performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     secrets: inherit
     with:
       java: "[17, 21, 25]"
-      os: '["ubuntu-latest", "windows-latest"]'
+      os: '["ubuntu-latest", "blacksmith-2vcpu-windows-2025"]'
       extraMavenArgs: 'verify'
 
   integration-tests:


### PR DESCRIPTION
## Summary
- Migrates Windows runner from `windows-latest` to `blacksmith-2vcpu-windows-2025`

## Benefits
- ~50% cost reduction for Windows CI/CD
- ~2x performance improvement

DAT-21557

🤖 Generated with [Claude Code](https://claude.com/claude-code)