### PR TITLE
fix(DAT-22684): pin all GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/manual-release-from-tag.yml
+++ b/.github/workflows/manual-release-from-tag.yml
@@ -17,27 +17,27 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tagName }}
 
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-release-published.yml
       - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "17"
           distribution: "temurin"
           cache: "maven"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -45,7 +45,7 @@ jobs:
 
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-release-published.yml
       - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@v22
+        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
         with:
           repositories: |
             [
@@ -118,7 +118,7 @@ jobs:
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-attach-artifact-release.yml
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ env.GPG_KEY_CONTENT }}
           passphrase: ${{ env.GPG_PASSPHRASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
             mysql: "8.4"
             mariadb: "10.6"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Install Perl modules
@@ -57,7 +57,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libdbd-mysql-perl
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'


### PR DESCRIPTION
## Summary
- Pins all third-party GitHub Action references to immutable commit SHAs
- Uses `@SHA # vX.Y.Z` format so Dependabot can continue tracking version updates
- Follows canonical SHA list maintained in liquibase/build-logic

## Security Impact
Prevents supply chain attacks where a compromised action maintainer could silently repoint a mutable version tag (e.g. `@v4`) to inject malicious code into workflows that handle AWS credentials, secrets, and publishing.

## Test Plan
- [ ] Verify no unpinned tags remain: `grep -rn 'uses:.*@v[0-9]' .github/` returns zero results for known actions
- [ ] Workflow syntax is valid

Closes DAT-22684. Part of DAT-21269.