### PR TITLE
refactor(ci): replace archived whelk-io with build-logic setup-maven-settings [DAT-22915]

### DIFF
--- a/.github/workflows/manual-release-from-tag.yml
+++ b/.github/workflows/manual-release-from-tag.yml
@@ -44,61 +44,35 @@ jobs:
           parse-json-secrets: true
 
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-release-published.yml
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
               {
                 "id": "liquibase",
                 "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
+                "releases": {"enabled": "true"},
+                "snapshots": {"enabled": "true", "updatePolicy": "always"}
               },
               {
                 "id": "liquibase-pro",
                 "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
+                "releases": {"enabled": "true"},
+                "snapshots": {"enabled": "true", "updatePolicy": "always"}
               },
               {
                 "id": "sonatype-nexus-staging",
                 "url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "false"
-                }
+                "releases": {"enabled": "true"},
+                "snapshots": {"enabled": "false"}
               }
             ]
           servers: |
             [
-              {
-                "id": "liquibase-pro",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "liquibase",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "sonatype-nexus-staging",
-                "username": "${{ env.SONATYPE_USERNAME }}",
-                "password": "${{ env.SONATYPE_TOKEN }}"
-              }
+              {"id": "liquibase-pro", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"},
+              {"id": "liquibase", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"},
+              {"id": "sonatype-nexus-staging", "username": "${{ env.SONATYPE_USERNAME }}", "password": "${{ env.SONATYPE_TOKEN }}"}
             ]
 
       - name: Convert escaped newlines and set GPG key


### PR DESCRIPTION
## Summary

Replace the single `whelk-io/maven-settings-xml-action` call site in `.github/workflows/manual-release-from-tag.yml` with the new first-party composite action [`liquibase/build-logic/.github/actions/setup-maven-settings`](https://github.com/liquibase/build-logic/pull/557) — in **advanced mode** (JSON passed through verbatim).

Jira: [DAT-22915](https://datical.atlassian.net/browse/DAT-22915)

## Why advanced mode

The existing config has one subtle property that simple mode can't preserve without distortion:
- **3 repositories** including `sonatype-nexus-staging` (Sonatype OSS release URL) with `"snapshots": {"enabled": "false"}`

Simple mode's `extra-repository-*` inputs would hardcode `snapshots.enabled=true` on any extra — that's a meaningful semantic drift for the Sonatype deploy URL. Advanced mode lets us pass the exact JSON and preserve byte-for-byte parity.

## Behavior preserved exactly

- 3 repositories: `liquibase`, `liquibase-pro`, `sonatype-nexus-staging` (with snapshots explicitly disabled)
- 3 servers: liquibase-pro and liquibase use `liquibot` + `LIQUIBOT_PAT_GPM_ACCESS`; sonatype-nexus-staging uses `SONATYPE_USERNAME` + `SONATYPE_TOKEN` (release credentials)

## Blocked by

🚧 [**liquibase/build-logic#557**](https://github.com/liquibase/build-logic/pull/557) must merge first.

## Test plan

- [x] YAML parses cleanly
- [x] No remaining `whelk-io` references
- [x] Sonatype repo's `snapshots.enabled=false` preserved (critical for release workflow correctness)
- [x] All 3 server credential expressions unchanged
- [ ] CI green post-merge of liquibase/build-logic#557 (next manual release run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)