### PR TITLE
ci: SHA-pin step-level build-logic action ref [TECHOPS-81]

### DIFF
--- a/.github/workflows/manual-release-from-tag.yml
+++ b/.github/workflows/manual-release-from-tag.yml
@@ -45,7 +45,7 @@ jobs:
 
       # taken from https://github.com/liquibase/build-logic/blob/main/.github/workflows/extension-release-published.yml
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           repositories: |
             [


### PR DESCRIPTION
## Summary

Pins step-level uses of `liquibase/build-logic/.github/actions/*@main` in this repo to build-logic `main` HEAD `2660ba3`. Unblocks the GitHub enterprise policy **Require actions to be pinned to a full-length commit SHA**.

Context: [TECHOPS-81](https://datical.atlassian.net/browse/TECHOPS-81). Companion PR (no merge-order dependency, both can land independently): [liquibase/build-logic#605](https://github.com/liquibase/build-logic/pull/605).

## Maintenance trade-off

Future changes to the pinned composite action(s) in build-logic will require an explicit SHA bump in this repo. Dependabot may or may not propose these self-referential bumps automatically: watch the next weekly run after merge.

## Test plan

- [ ] CI green on this branch (workflows still resolve the pinned actions).
- [ ] After merge, confirm the affected workflow(s) still run end-to-end on a sample trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-81]: https://datical.atlassian.net/browse/TECHOPS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ